### PR TITLE
[Feat/#2] 이슈 등록 Controller 테스트 실패 문제 해결

### DIFF
--- a/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
@@ -33,7 +33,7 @@ class IssueControllerTest {
 
         IssueCreateRequest request = new IssueCreateRequest("testMember", "testTitle", "testContent");
         final String requestJson = objectMapper.writeValueAsString(request);
-        given(issueService.create(request)).willReturn(1L);
+        given(issueService.create(any(IssueCreateRequest.class))).willReturn(1L);
 
         // when
         final ResultActions result = mockMvc.perform(
@@ -45,4 +45,5 @@ class IssueControllerTest {
         result.andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/issues/1"));
     }
+
 }


### PR DESCRIPTION
# 🚀 Pull Request
## 구현 내용
이슈 등록 Controller 테스트 실패 원인을 찾고 문제를 해결했습니다.
해결 방법은 아래 인용과 같습니다. 원본은 아래 url을 참고해주세요

[[FIX] IssueControllerTest 실패 현상 수정](https://github.com/codesquad-masters2024-team09/issue-tracker/issues/2#issuecomment-2102500625)
> ## 발생 원인
> 해당 테스트 코드에서 직접 new로 생성한 IssueCreateRequest와 mockMvc.perform()에서 생성되는 IssueCreateRequest는 서로 다른 객체다. 내부 값은 같더라도 주소값이 다르다. 따라서 `given(issueService.create(request)).willReturn(1L);`이 호출되지 않았고, Mockito는 이 경우 기본값인 0을 반환한 것.
> 
> ## 해결 방법
> `given(issueService.create(any(IssueCreateRequest.class))).willReturn(1L);`
> 
> Mockito의 any() 메서드를 사용해 해결했다. 위 구문은 어떤 IssueCreateRequest 타입이 매개변수로 전달되든 1L을 리턴하겠다는 것을 의미한다.

## 기타
해당 테스트코드에 DisplayName 어노테이션이 누락되었습니다.
다른 이슈에서 해결하도록 하겠습니다.

## 관련 이슈
close #2 
