### PR TITLE
[Feat/#4] 이슈 수정 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -1,15 +1,18 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
 
 @RestController
 @RequestMapping("/issues")
@@ -22,6 +25,15 @@ public class IssueController {
     public ResponseEntity<Void> create(@Valid @RequestBody IssueCreateRequest request) {
         return ResponseEntity
                 .created(URI.create("/issues/" + issueService.create(request)))
+                .build();
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> edit(@PathVariable("id") Long id, @Valid @RequestBody IssueUpdateRequest request) {
+        issueService.edit(request);
+        return ResponseEntity
+                .status(HttpStatus.FOUND)
+                .location(URI.create("/issues/" + id))
                 .build();
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -5,7 +5,6 @@ import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,8 +31,7 @@ public class IssueController {
     public ResponseEntity<Void> edit(@PathVariable("id") Long id, @Valid @RequestBody IssueUpdateRequest request) {
         issueService.edit(request);
         return ResponseEntity
-                .status(HttpStatus.FOUND)
-                .location(URI.create("/issues/" + id))
+                .ok()
                 .build();
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueMapper.java
@@ -1,0 +1,9 @@
+package com.issuetracker.domain.issue;
+
+import com.issuetracker.domain.issue.request.IssueUpdateRequest;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface IssueMapper {
+    void update(IssueUpdateRequest form);
+}

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -1,6 +1,7 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,10 +10,19 @@ import org.springframework.stereotype.Service;
 public class IssueService {
 
     private final IssueRepository issueRepository;
+    private final IssueMapper issueMapper;
 
     public Long create(IssueCreateRequest request) {
         Issue issue = request.toEntity();
         Issue savedIssue = issueRepository.save(issue);
         return savedIssue.getId();
+    }
+
+    public void edit(IssueUpdateRequest form) {
+        if (form.getTitle() == null && form.getContent() == null) {
+            throw new IllegalArgumentException();
+        }
+
+        issueMapper.update(form);
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueUpdateRequest.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.issuetracker.domain.issue.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IssueUpdateRequest {
+
+    @NotNull(message = "Issue Id가 Null 일 수 없습니다")
+    private Long issueId;
+    private String title;
+    private String content;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,23 @@ spring:
   sql:
     init:
       mode: always
+
+# mybatis
+mybatis:
+  mapper-locations: classpath:mapper/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true
+
+# logging
+logging:
+  level:
+    org:
+      springframework:
+        data: INFO
+        jdbc:
+          core:
+            JdbcTemplate: DEBUG
+    com:
+      issuetracker:
+        domain:
+          issue: TRACE

--- a/src/main/resources/mapper/issue/Issue.xml
+++ b/src/main/resources/mapper/issue/Issue.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.issuetracker.domain.issue.IssueMapper">
+
+    <update id="update" parameterType="com.issuetracker.domain.issue.request.IssueUpdateRequest">
+        UPDATE ISSUE
+        <set>
+            <if test="title != null">
+                TITLE = #{title},
+            </if>
+            <if test="content != null">
+                CONTENT = #{content},
+            </if>
+        </set>
+        WHERE ISSUE_ID = #{issueId}
+    </update>
+
+</mapper>

--- a/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
@@ -2,6 +2,8 @@ package com.issuetracker.domain.issue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueUpdateRequest;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -11,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -46,4 +49,24 @@ class IssueControllerTest {
                 .andExpect(header().string("Location", "/issues/1"));
     }
 
+    @Test
+    @DisplayName("이슈 id가 1번의 제목을 'Hello update' 로 수정 요청하면 '/issues/1' 로 리다이렉트 된다")
+    void editTitle() throws Exception {
+        // given
+        String url = "/issues/1";
+        String updatedTitle = "Hello update";
+
+        IssueUpdateRequest request = new IssueUpdateRequest(1L, updatedTitle, null);
+        String requestJson = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                patch(url).content(requestJson)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/issues/1"));
+    }
 }

--- a/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
@@ -66,7 +66,6 @@ class IssueControllerTest {
         );
 
         // then
-        result.andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/issues/1"));
+        result.andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/issuetracker/domain/issue/request/IssueUpdateRequestTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/request/IssueUpdateRequestTest.java
@@ -1,0 +1,56 @@
+package com.issuetracker.domain.issue.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class IssueUpdateRequestTest {
+
+    @Autowired
+    private Validator validator;
+
+    @Test
+    @DisplayName("issueId 필드가 Null 이면 @NotNull 검증을 통과하지 못한다")
+    void validate_fail_when_id_id_null() {
+        // given
+        IssueUpdateRequest form = IssueUpdateRequest.builder().build();
+
+        // when
+        Set<ConstraintViolation<IssueUpdateRequest>> violations = validator.validate(form);
+
+        Iterator<ConstraintViolation<IssueUpdateRequest>> iterator = violations.iterator();
+        List<String> message = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            ConstraintViolation<IssueUpdateRequest> next = iterator.next();
+            message.add(next.getMessage());
+        }
+
+        // then
+        assertThat(message).hasSize(1);
+        assertThat(message.get(0)).isEqualTo("Issue Id가 Null 일 수 없습니다");
+    }
+
+    @Test
+    @DisplayName("issueId 필드가 null 이 아니면 @NotNull 검증에 통과한다")
+    void validate_success() {
+        // given
+        IssueUpdateRequest form = IssueUpdateRequest.builder().issueId(1L).build();
+
+        // when
+        Set<ConstraintViolation<IssueUpdateRequest>> violations = validator.validate(form);
+
+        // then
+        assertThat(violations).isEmpty();
+    }
+}

--- a/src/test/java/com/issuetracker/domain/issue/request/IssueUpdateRequestTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/request/IssueUpdateRequestTest.java
@@ -21,7 +21,7 @@ class IssueUpdateRequestTest {
 
     @Test
     @DisplayName("issueId 필드가 Null 이면 @NotNull 검증을 통과하지 못한다")
-    void validate_fail_when_id_id_null() {
+    void validate_fail_when_id_is_null() {
         // given
         IssueUpdateRequest form = IssueUpdateRequest.builder().build();
 


### PR DESCRIPTION
# 🚀 Pull Request
- 이슈의 제목, 내용을 수정하는 기능을 구현하여 PR을 요청합니다.
- postman 및 ajax 요청으로 제목, 수정에 대한 테스트를 완료했습니다.

## 구현 내용
- 이슈의 제목 또는 내용을 수정할 때, `수정`이라는 기능 관점에서 제목따로 내용따로 메서드를 만들지 않고, `수정`하는 단일 메서드에서 동작하도록 구현했습니다.
  - 그 이유는 유지보수 관점에서, `이슈를 수정한다` 라는 행위를 여러 메서드로 나누게 되면 중복 코드가 생겨 유지보수 대상 코드가 늘어난다는 단점을 최소화하기 위함입니다.
  - 이를 해결하기위해 mybatis를 이용하면 동적 쿼리 처리 기능을 이용하여 단일 메서드로 처리할 수 있습니다.

```mermaid
---
title: 수정한다가 2개의 함수로 나눠서 관리하기 vs 1개의 함수에서만 관리하기
---
flowchart LR
  subgraph 각각 관리하기
  direction LR
  update1["수정한다"] --> updateTitle & updateContent
  end

  subgraph 하나에서 관리하기
  direction LR
  update2["수정한다"] --> update
  end
```

## 관련 이슈
close Feat/#4
