### PR TITLE
[Feat/#5] 이슈 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -1,13 +1,12 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import jakarta.validation.Valid;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -23,5 +22,11 @@ public class IssueController {
         return ResponseEntity
                 .created(URI.create("/issues/" + issueService.create(request)))
                 .build();
+    }
+
+    @GetMapping("/{issueId}")
+    public ResponseEntity<IssueDetailResponse> detail(@PathVariable Long issueId) {
+        return ResponseEntity
+                .ok(issueService.getDetail(issueId));
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -1,6 +1,7 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,5 +15,14 @@ public class IssueService {
         Issue issue = request.toEntity();
         Issue savedIssue = issueRepository.save(issue);
         return savedIssue.getId();
+    }
+
+    public IssueDetailResponse getDetail(Long issueId) {
+         Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
+         return IssueDetailResponse.builder()
+                 .memberId(issue.getMemberId())
+                 .title(issue.getTitle())
+                 .content(issue.getContent())
+                 .build();
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -1,6 +1,7 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,6 @@ public class IssueService {
                  .content(issue.getContent())
                  .build();
     }
-}
 
     public void edit(IssueUpdateRequest form) {
         if (form.getTitle() == null && form.getContent() == null) {

--- a/src/main/java/com/issuetracker/domain/issue/response/IssueDetailResponse.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/IssueDetailResponse.java
@@ -1,0 +1,16 @@
+package com.issuetracker.domain.issue.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class IssueDetailResponse {
+
+    private Long id;
+    private String memberId;
+    private String title;
+    private String content;
+}

--- a/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
@@ -2,7 +2,11 @@ package com.issuetracker.domain.issue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.response.IssueDetailResponse;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -11,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -44,5 +49,25 @@ class IssueControllerTest {
         // then
         result.andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/issues/1"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {1, 2, 3})
+    @DisplayName("이슈의 id를 통해 해당 id issue의 상세 내용을 조회할 수 있다")
+    void detail(Long issueId) throws Exception {
+        // given
+        String url = "/issues/" + issueId.toString();
+        IssueDetailResponse response = IssueDetailResponse.builder()
+                .id(issueId)
+                .build();
+        given(issueService.getDetail(issueId)).willReturn(response);
+
+        // when
+        ResultActions result = mockMvc.perform(get(url));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(objectMapper.writeValueAsString(response)));
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request
[Feat/#5] 이슈 상세 조회 기능을 구현하여 내부적으로 PR을 작성합니다.

## 구현 내용
- 이슈 식별자인 `issueId`를 통해 해당 이슈의 상세 정보를 조회하는 기능을 추가하였습니다.
- 현재 정상적으로 상세 내용 조회에 성공했을 경우만 구현하였습니다. 이후 실패, 예외 상황에 대해서도 구현할 예정입니다.

## 고민 사항
- DTO 역할을 수행하는 `IssueDetailResponse` 와 엔티티인 `Issue` 의 코드가 거의 같습니다.
  - 서비스 계층에서 컨트롤러 계층으로 이동할 때는 DTO를 이용한다는 원칙에 맞춰 작성하였으나, 코드가 대부분 겹치는 것이 신경 쓰이는 것 같습니다.
  - 이후 상세 내용에 마일스톤, 오픈 여부 등 추가적인 정보가 생긴다면 이러한 고민이 줄지 않을까 싶습니다. 

## 관련 이슈
close #issue-number
