### PR TITLE
Feat/#7 이슈 등록 시 입력 데이터 유효성 검증, 테스트 코드 작성

### DIFF
--- a/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class IssueCreateRequest {
 

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
@@ -2,6 +2,7 @@ package com.issuetracker.domain.issue.request;
 
 import com.issuetracker.domain.issue.Issue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,9 +14,11 @@ public class IssueCreateRequest {
     private String memberId;
 
     @NotBlank
+    @Size(max = 120)
     private String title;
 
     @NotBlank
+    @Size(max = 2000)
     private String content;
 
     public Issue toEntity() {

--- a/src/main/java/com/issuetracker/global/config/WebConfig.java
+++ b/src/main/java/com/issuetracker/global/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.issuetracker.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.setOrder(Ordered.HIGHEST_PRECEDENCE);
+
+        registry.addViewController("/").setViewName("/issue/addIssue");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,13 @@ spring:
   sql:
     init:
       mode: always
+
+  # cache settings (true at prod env)
+  thymeleaf:
+    cache: false
+
+  # check file exists at template directory
+    check-template-location: true
+
+    prefix : classpath:/templates/
+    suffix : .html

--- a/src/main/resources/templates/issue/addIssue.html
+++ b/src/main/resources/templates/issue/addIssue.html
@@ -21,7 +21,7 @@
     <section>
         <h2>새로운 이슈 작성</h2>
         <hr/>
-        <form id="addIssue" action="/issues" method="post">
+        <form id="add-issue" action="/issues" method="post">
             <a href="">
                 <img src="" alt="작성자 프로필">
                 <label id="memberId">
@@ -33,9 +33,13 @@
                 <input type="text" name="title" placeholder="제목">
             </label>
             <label id="content">
-                <textarea name="content" placeholder="코멘트를 입력하세요" cols="100" rows="15"></textarea>
+                <textarea name="content" placeholder="코멘트를 입력하세요"></textarea>
             </label>
         </form>
+        <button id="img-upload" onclick="">
+            <img src="" alt="첨부파일 아이콘">
+            파일 첨부하기
+        </button>
         <hr/>
     </section>
     <aside>
@@ -70,9 +74,9 @@
         e.preventDefault();
 
         const formData = {
-            memberId: $("#addIssue input[name=memberId]").val(),
-            title: $("#addIssue input[name=title]").val(),
-            content: $("#addIssue textarea[name=content]").val()
+            memberId: $("#add-issue input[name=memberId]").val(),
+            title: $("#add-issue input[name=title]").val(),
+            content: $("#add-issue textarea[name=content]").val()
         }
 
         $.ajax({

--- a/src/main/resources/templates/issue/addIssue.html
+++ b/src/main/resources/templates/issue/addIssue.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4=" crossorigin="anonymous"></script>
+    <title>Add Issue</title>
+</head>
+<body>
+<header>
+    <a href="/issues">
+        <img src="" alt="이슈 트래커 로고"/>
+    </a>
+    <a href="">
+        <img src="" alt="내 프로필">
+    </a>
+</header>
+<main>
+    <section>
+        <h2>새로운 이슈 작성</h2>
+        <hr/>
+        <form id="addIssue" action="/issues" method="post">
+            <a href="">
+                <img src="" alt="작성자 프로필">
+                <label id="memberId">
+                    <!--기본 tester 삭제-->
+                    <input type="hidden" name="memberId" th:value="tester">
+                </label>
+            </a>
+            <label id="title">
+                <input type="text" name="title" placeholder="제목">
+            </label>
+            <label id="content">
+                <textarea name="content" placeholder="코멘트를 입력하세요" cols="100" rows="15"></textarea>
+            </label>
+        </form>
+        <hr/>
+    </section>
+    <aside>
+        <ul>
+            <li>
+                <label for="assignee">담당자</label>
+                <button id="assignee">+</button>
+            </li>
+            <li>
+                <label for="label">레이블</label>
+                <button id="label">+</button>
+            </li>
+            <li>
+                <label for="milestone">마일스톤</label>
+                <button id="milestone">+</button>
+            </li>
+        </ul>
+    </aside>
+    <div>
+        <button type="button" onclick="">작성 취소</button>
+        <button type="submit" id="issue-add-button">완료</button>
+    </div>
+</main>
+
+<script>
+    $(document).ready(function () {
+        $("#issue-add-button").click(addIssue);
+    })
+
+    function addIssue(e) {
+
+        e.preventDefault();
+
+        const formData = {
+            memberId: $("#addIssue input[name=memberId]").val(),
+            title: $("#addIssue input[name=title]").val(),
+            content: $("#addIssue textarea[name=content]").val()
+        }
+
+        $.ajax({
+            type: 'POST',
+            url: '/issues',
+            contentType: "application/json",
+            data: JSON.stringify(formData),
+            success: function (data, textStatus, jqXHR) {
+                const location = jqXHR.getResponseHeader('Location');
+                if (location) {
+                    window.location.href = location;
+                }
+            },
+            error: function () {
+                alert("error occurred!");
+            }
+        });
+
+    }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
# 🚀 Pull Request

## 구현 내용
이슈 등록 시 입력 데이터 (memberId, title, content)에 대해 공백 여부 체크, title과 content의 경우 글자수 제한과 같은 유효성 검증 로직을 추가했습니다.
유효성 검증 로직에 대한 테스트코드도 작성했습니다.

html과 js로 이슈 등록 폼을 만들어 브라우저 환경에서 이슈가 등록되는 것도 확인했습니다.

## 기타
- 파일 첨부 시 S3로 이미지 업로드하고 textarea에 마크다운 형식으로 추가하는 코드는 별도의 이슈에서 작성합니다.

## 관련 이슈
close #7 
