### PR TITLE
Feat/#26 이슈 등록 시 레이블과 마일스톤 함께 등록, 이슈에 레이블 추가, 이슈에 마일스톤 추가 구현

### DIFF
--- a/src/main/java/com/issuetracker/domain/comment/Comment.java
+++ b/src/main/java/com/issuetracker/domain/comment/Comment.java
@@ -19,7 +19,7 @@ public class Comment extends BaseDateTime {
     @Id
     @Column("COMMENT_ID")
     private Long id;
-    private String member_id;
-    private Long issue_id;
+    private String memberId;
+    private Long issueId;
     private String content;
 }

--- a/src/main/java/com/issuetracker/domain/comment/request/CommentCreateRequest.java
+++ b/src/main/java/com/issuetracker/domain/comment/request/CommentCreateRequest.java
@@ -27,8 +27,8 @@ public class CommentCreateRequest {
 
     public Comment toEntity() {
         return Comment.builder()
-                .member_id(memberId)
-                .issue_id(issueId)
+                .memberId(memberId)
+                .issueId(issueId)
                 .content(content)
                 .build();
     }

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -2,6 +2,7 @@ package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
 import com.issuetracker.domain.issue.request.IssueLabelCreateRequest;
+import com.issuetracker.domain.issue.request.IssueMilestoneCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import jakarta.validation.Valid;
@@ -24,10 +25,17 @@ public class IssueController {
                 .ok(Collections.singletonMap("issueId", issueService.create(request)));
     }
 
-    @PostMapping("/{issueId}")
+    @PostMapping("/{issueId}/label")
     public ResponseEntity<Void> addLabel(@PathVariable("issueId") Long issueId,
                                       @Valid @RequestBody IssueLabelCreateRequest issueLabelCreateRequest) {
         issueService.addLabel(issueId, issueLabelCreateRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{issueId}/milestone")
+    public ResponseEntity<Void> assignMilestone(@PathVariable("issueId") Long issueId,
+                                                @Valid @RequestBody IssueMilestoneCreateRequest issueMilestoneCreateRequest) {
+        issueService.assignMilestone(issueId, issueMilestoneCreateRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -1,6 +1,7 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueLabelCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import jakarta.validation.Valid;
@@ -21,6 +22,13 @@ public class IssueController {
     public ResponseEntity<?> create(@Valid @RequestBody IssueCreateRequest request) {
         return ResponseEntity
                 .ok(Collections.singletonMap("issueId", issueService.create(request)));
+    }
+
+    @PostMapping("/{issueId}")
+    public ResponseEntity<Void> addLabel(@PathVariable("issueId") Long issueId,
+                                      @Valid @RequestBody IssueLabelCreateRequest issueLabelCreateRequest) {
+        issueService.addLabel(issueId, issueLabelCreateRequest);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/{issueId}")

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -5,11 +5,10 @@ import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
+import java.util.Collections;
 
 @RestController
 @RequestMapping("/api/v1/issues")
@@ -19,10 +18,9 @@ public class IssueController {
     private final IssueService issueService;
 
     @PostMapping
-    public ResponseEntity<Void> create(@Valid @RequestBody IssueCreateRequest request) {
+    public ResponseEntity<?> create(@Valid @RequestBody IssueCreateRequest request) {
         return ResponseEntity
-                .created(URI.create("/issues/" + issueService.create(request)))
-                .build();
+                .ok(Collections.singletonMap("issueId", issueService.create(request)));
     }
 
     @GetMapping("/{issueId}")
@@ -34,10 +32,7 @@ public class IssueController {
     @DeleteMapping("/{issueId}")
     public ResponseEntity<Void> delete(@PathVariable("issueId") Long issueId) {
         issueService.delete(issueId);
-        String redirectUrl = "/";
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .header("Location", redirectUrl)
-                .build();
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{issueId}")

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -2,6 +2,7 @@ package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
+import com.issuetracker.domain.label.LabelRepository;
 import lombok.RequiredArgsConstructor;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import java.util.Map;
 import com.issuetracker.domain.issue.response.IssueListResponse;
 import com.issuetracker.domain.issue.response.IssueResponse;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,10 +21,17 @@ import java.util.stream.Collectors;
 public class IssueService {
 
     private final IssueRepository issueRepository;
+    private final LabelRepository labelRepository;
     private final IssueMapper issueMapper;
 
     public Long create(IssueCreateRequest request) {
         Issue issue = request.toEntity();
+        issue.addLabels(
+                request.getLabels().stream().map(
+                        labelId -> labelRepository.findById(labelId)
+                                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 레이블입니다."))
+                ).collect(Collectors.toList())
+        );
         Issue savedIssue = issueRepository.save(issue);
         return savedIssue.getId();
     }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -1,6 +1,7 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueLabelCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.label.LabelRepository;
 import com.issuetracker.domain.milestone.MilestoneRepository;
@@ -74,11 +75,13 @@ public class IssueService {
         );
     }
 
-    public Issue addLabel(Long issueId, Label label) {
+    public void addLabel(Long issueId, IssueLabelCreateRequest request) {
         Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
-        issue.addLabel(label);
+        issue.addLabel(
+                labelRepository.findById(request.getLabelId())
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 레이블입니다.")));
 
-        return issueRepository.save(issue);
+        issueRepository.save(issue);
     }
 
     public Issue addLabels(Long issueId, List<Label> labels) {

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -2,6 +2,7 @@ package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
 import com.issuetracker.domain.issue.request.IssueLabelCreateRequest;
+import com.issuetracker.domain.issue.request.IssueMilestoneCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.label.LabelRepository;
 import com.issuetracker.domain.milestone.MilestoneRepository;
@@ -9,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
 import com.issuetracker.domain.label.Label;
-import com.issuetracker.domain.milestone.Milestone;
 import java.util.HashMap;
 import java.util.Map;
 import com.issuetracker.domain.issue.response.IssueListResponse;
@@ -98,11 +98,14 @@ public class IssueService {
         return issueRepository.save(issue);
     }
 
-    public Issue assignMilestone(Long issueId, Milestone milestone) {
+    public void assignMilestone(Long issueId, IssueMilestoneCreateRequest request) {
         Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
-        issue.assignMilestone(milestone);
+        issue.assignMilestone(
+                milestoneRepository.findById(request.getMilestoneId())
+                        .orElseThrow(() -> new NoSuchElementException("존재하지 않는 마일스톤입니다."))
+        );
 
-        return issueRepository.save(issue);
+        issueRepository.save(issue);
     }
 
     public Issue deleteMilestone(Long issueId) {

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -3,6 +3,7 @@ package com.issuetracker.domain.issue;
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.label.LabelRepository;
+import com.issuetracker.domain.milestone.MilestoneRepository;
 import lombok.RequiredArgsConstructor;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ public class IssueService {
 
     private final IssueRepository issueRepository;
     private final LabelRepository labelRepository;
+    private final MilestoneRepository milestoneRepository;
     private final IssueMapper issueMapper;
 
     public Long create(IssueCreateRequest request) {
@@ -32,6 +34,14 @@ public class IssueService {
                                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 레이블입니다."))
                 ).collect(Collectors.toList())
         );
+
+        if (request.getMilestoneId() != null) {
+            issue.assignMilestone(
+                    milestoneRepository.findById(request.getMilestoneId())
+                            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 마일스톤입니다."))
+            );
+        }
+
         Issue savedIssue = issueRepository.save(issue);
         return savedIssue.getId();
     }

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
@@ -2,10 +2,13 @@ package com.issuetracker.domain.issue.request;
 
 import com.issuetracker.domain.issue.Issue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -22,6 +25,9 @@ public class IssueCreateRequest {
     @NotBlank
     @Size(max = 2000)
     private String content;
+
+    @NotNull
+    private List<String> labels;
 
     public Issue toEntity() {
         return Issue.builder()

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueCreateRequest.java
@@ -29,6 +29,8 @@ public class IssueCreateRequest {
     @NotNull
     private List<String> labels;
 
+    private String milestoneId;
+
     public Issue toEntity() {
         return Issue.builder()
                 .memberId(memberId)

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueLabelCreateRequest.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueLabelCreateRequest.java
@@ -1,0 +1,15 @@
+package com.issuetracker.domain.issue.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class IssueLabelCreateRequest {
+
+    @NotBlank
+    private String labelId;
+}

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueMilestoneCreateRequest.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueMilestoneCreateRequest.java
@@ -1,0 +1,15 @@
+package com.issuetracker.domain.issue.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class IssueMilestoneCreateRequest {
+
+    @NotBlank
+    private String milestoneId;
+}

--- a/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
@@ -54,7 +54,7 @@ class IssueControllerTest {
 
         IssueCreateRequest request =
                 new IssueCreateRequest("testMember", "testTitle", "testContent",
-                        List.of("bug", "fix"));
+                        List.of("bug", "fix"), "테스트 기능 구현");
         String requestJson = objectMapper.writeValueAsString(request);
         given(issueService.create(any(IssueCreateRequest.class))).willReturn(1L);
 
@@ -84,7 +84,8 @@ class IssueControllerTest {
                 dynamicTest("제목은 최대 120자 이내여야 한다.", () -> {
                     // given
                     IssueCreateRequest tooLongTitle =
-                            new IssueCreateRequest(memberId, title.repeat(120 + 1), content, List.of());
+                            new IssueCreateRequest(memberId, title.repeat(120 + 1), content, List.of(),
+                                    "테스트 기능 구현");
                     String requestJson = objectMapper.writeValueAsString(tooLongTitle);
 
                     // when
@@ -100,7 +101,8 @@ class IssueControllerTest {
                 dynamicTest("내용은 최대 2000자 이내여야 한다.", () -> {
                     // given
                     IssueCreateRequest tooLongContent
-                            = new IssueCreateRequest(memberId, title, content.repeat(2000 + 1), List.of());
+                            = new IssueCreateRequest(memberId, title, content.repeat(2000 + 1), List.of(),
+                            "테스트 기능 구현");
                     String requestJson = objectMapper.writeValueAsString(tooLongContent);
 
                     // when
@@ -113,9 +115,10 @@ class IssueControllerTest {
                     result.andExpect(status().is4xxClientError());
                 }),
 
-                dynamicTest("모든 필드는 공백이거나 빈 값, null이어선 안 된다.", () -> {
+                dynamicTest("마일스톤 아이디를 제외한 모든 필드는 공백이거나 빈 값, null이어선 안 된다.", () -> {
                     // given
-                    IssueCreateRequest blankRequest = new IssueCreateRequest(" ", " ", " ", null);
+                    IssueCreateRequest blankRequest = new IssueCreateRequest(" ", " ", " ",
+                            null, null);
                     String requestJson = objectMapper.writeValueAsString(blankRequest);
 
                     // when
@@ -131,7 +134,7 @@ class IssueControllerTest {
     }
 
     @Test
-    @DisplayName("이슈 id가 1번의 제목을 'Hello update' 로 수정 요청하면 '/issues/1' 로 리다이렉트 된다")
+    @DisplayName("이슈 id가 1번의 제목을 'Hello update' 로 수정 요청하면 200 OK를 응답한다")
     void editTitle() throws Exception {
         // given
         String url = urlPrefix + "/issues/1";

--- a/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
@@ -3,6 +3,7 @@ package com.issuetracker.domain.issue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
 import com.issuetracker.domain.issue.request.IssueLabelCreateRequest;
+import com.issuetracker.domain.issue.request.IssueMilestoneCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -76,11 +77,32 @@ class IssueControllerTest {
     void add_label() throws Exception {
         // given
         Long issueId = 1L;
-        String url = urlPrefix + "/issues/" + issueId;
+        String url = urlPrefix + "/issues/" + issueId + "/label";
 
         IssueLabelCreateRequest request = new IssueLabelCreateRequest("bug");
         String requestJson = objectMapper.writeValueAsString(request);
         willDoNothing().given(issueService).addLabel(anyLong(), any(IssueLabelCreateRequest.class));
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post(url).content(requestJson)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("이슈에 마일스톤 추가를 성공하면 200 OK를 응답한다.")
+    void assign_milestone() throws Exception {
+        // given
+        Long issueId = 1L;
+        String url = urlPrefix + "/issues/" + issueId + "/milestone";
+
+        IssueMilestoneCreateRequest request = new IssueMilestoneCreateRequest("테스트 기능 구현");
+        String requestJson = objectMapper.writeValueAsString(request);
+        willDoNothing().given(issueService).assignMilestone(anyLong(), any(IssueMilestoneCreateRequest.class));
 
         // when
         ResultActions result = mockMvc.perform(

--- a/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueControllerTest.java
@@ -2,6 +2,7 @@ package com.issuetracker.domain.issue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueLabelCreateRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -68,6 +69,27 @@ class IssueControllerTest {
         result.andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json("{issueId: 1}"));
+    }
+
+    @Test
+    @DisplayName("이슈에 레이블 추가를 성공하면 200 OK를 응답한다.")
+    void add_label() throws Exception {
+        // given
+        Long issueId = 1L;
+        String url = urlPrefix + "/issues/" + issueId;
+
+        IssueLabelCreateRequest request = new IssueLabelCreateRequest("bug");
+        String requestJson = objectMapper.writeValueAsString(request);
+        willDoNothing().given(issueService).addLabel(anyLong(), any(IssueLabelCreateRequest.class));
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post(url).content(requestJson)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andExpect(status().isOk());
     }
 
     @TestFactory

--- a/src/test/java/com/issuetracker/domain/issue/IssueTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueTest.java
@@ -150,8 +150,8 @@ class IssueTest {
 
         for (int i = 0; i < 3; i++) {
             Comment comment = Comment.builder()
-                    .issue_id(savedIssue.getId())
-                    .member_id(testMember.getId())
+                    .issueId(savedIssue.getId())
+                    .memberId(testMember.getId())
                     .content("test comment" + i)
                     .build();
 


### PR DESCRIPTION
# 🚀 Pull Request

## 구현 내용
- 이슈 등록 시 레이블과 마일스톤을 함께 등록하는 기능, 등록된 이슈에 레이블을 추가하는 기능, 등록된 이슈에 마일스톤을 추가하는 기능을 구현했습니다.
- 이슈 등록 시 레이블은 notNull로, 빈 배열이라도 요청해야 하도록 구현했습니다.
- 또한 이슈 등록 시 요청에 레이블 리스트나 마일스톤 값이 있다면 labelRepository와 milestoneRepository에서 각각 존재하는지 조회해서 등록합니다.
- Comment 엔터티 필드명이 스네이크 케이스로 되어있던 부분도 함께 수정했습니다

## 고민 사항
- 등록 시 요청으로 Label이나 Milestone 자체를 받을 수 없어 labelId 목록와 milestoneId를 입력받도록 구현했는데, 더 좋은 방법이 존재하는 지 찾아봐야 할 것 같습니다.

## 관련 이슈
close #26 
