### PR TITLE
[fix/#28] fix: 댓글 추가 시 생성 시간 초기화 수정 완료

### DIFF
--- a/src/main/java/com/issuetracker/domain/comment/Comment.java
+++ b/src/main/java/com/issuetracker/domain/comment/Comment.java
@@ -1,6 +1,7 @@
 package com.issuetracker.domain.comment;
 
 import com.issuetracker.domain.common.BaseDateTime;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -22,4 +23,10 @@ public class Comment extends BaseDateTime {
     private String memberId;
     private Long issueId;
     private String content;
+
+    public void initBaseDateTime() {
+        LocalDateTime now = LocalDateTime.now();
+        setCreatedAt(now);
+        setModifiedAt(now);
+    }
 }

--- a/src/main/java/com/issuetracker/domain/common/BaseDateTime.java
+++ b/src/main/java/com/issuetracker/domain/common/BaseDateTime.java
@@ -1,16 +1,19 @@
 package com.issuetracker.domain.common;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 public abstract class BaseDateTime {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
     @LastModifiedDate
     private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/issuetracker/domain/issue/Issue.java
+++ b/src/main/java/com/issuetracker/domain/issue/Issue.java
@@ -48,6 +48,7 @@ public class Issue extends BaseDateTime {
 
 
     public void addComment(Comment comment) {
+        comment.initBaseDateTime();
         this.comments.add(comment);
     }
 


### PR DESCRIPTION
# 🚀 Pull Request
댓글 추가 시 AggregateRoot 인 Issue 의 종속된 Comment에는 JdbcAuditing 기능이 적용되지 않는 문제를 해결했습니다.

## 구현 내용
- 댓글 생성 시 createdAt, modifiedAt 초기화

## 관련 이슈
close #28 
