### PR TITLE
[Feat/#35] 이슈 필터 및 검색 기능 구현

### DIFF
--- a/src/main/java/com/issuetracker/domain/issue/AggregateReferenceTypeHandler.java
+++ b/src/main/java/com/issuetracker/domain/issue/AggregateReferenceTypeHandler.java
@@ -1,0 +1,36 @@
+package com.issuetracker.domain.issue;
+
+import com.issuetracker.domain.milestone.Milestone;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
+
+public class AggregateReferenceTypeHandler extends BaseTypeHandler<AggregateReference<Milestone, String>> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, AggregateReference<Milestone, String> parameter, JdbcType jdbcType) throws SQLException {
+        ps.setString(i, parameter.getId());
+    }
+
+    @Override
+    public AggregateReference<Milestone, String> getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String id = rs.getString(columnName);
+        return id != null ? AggregateReference.to(id) : null;
+    }
+
+    @Override
+    public AggregateReference<Milestone, String> getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String id = rs.getString(columnIndex);
+        return id != null ? AggregateReference.to(id) : null;
+    }
+
+    @Override
+    public AggregateReference<Milestone, String> getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String id = cs.getString(columnIndex);
+        return id != null ? AggregateReference.to(id) : null;
+    }
+}

--- a/src/main/java/com/issuetracker/domain/issue/Issue.java
+++ b/src/main/java/com/issuetracker/domain/issue/Issue.java
@@ -45,7 +45,6 @@ public class Issue extends BaseDateTime {
     @Column("MILESTONE_ID")
     private AggregateReference<Milestone, String> milestoneRef;
 
-
     public void addComment(Comment comment) {
         comment.initBaseDateTime();
         this.comments.add(comment);

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -1,13 +1,18 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
+import com.issuetracker.domain.issue.request.IssueSearchCondition;
 import com.issuetracker.domain.issue.request.LabelAddRequest;
 import com.issuetracker.domain.issue.request.MilestoneAssignRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
+import com.issuetracker.domain.issue.response.IssueListResponse;
+import com.issuetracker.domain.issue.response.IssueResponse;
 import jakarta.validation.Valid;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,7 +34,7 @@ public class IssueController {
 
     @PostMapping("/{issueId}/label")
     public ResponseEntity<Void> addLabel(@PathVariable("issueId") Long issueId,
-                                      @Valid @RequestBody LabelAddRequest labelAddRequest) {
+                                         @Valid @RequestBody LabelAddRequest labelAddRequest) {
         issueService.addLabel(issueId, labelAddRequest.getLabelId());
         return ResponseEntity.ok().build();
     }
@@ -67,5 +72,17 @@ public class IssueController {
         return ResponseEntity
                 .ok()
                 .build();
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getIssuesByCondition(@RequestParam("q") String condition) {
+        List<Issue> issues = issueService.getIssueByCondition(IssueSearchCondition.of(condition));
+
+        List<IssueResponse> issueResponses = issues.stream()
+                .map(IssueResponse::of)
+                .collect(Collectors.toList());
+
+        return ResponseEntity
+                .ok(IssueListResponse.of(issueResponses));
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueLabelMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueLabelMapper.java
@@ -1,0 +1,9 @@
+package com.issuetracker.domain.issue;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface IssueLabelMapper {
+
+    IssueLabel findByIssueId(Long issueId);
+}

--- a/src/main/java/com/issuetracker/domain/issue/IssueMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueMapper.java
@@ -1,10 +1,14 @@
 package com.issuetracker.domain.issue;
 
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.Map;
 
 @Mapper
 public interface IssueMapper {
+
     void update(Map<String, Object> requestMap);
+
+    List<Issue> findByCondition(Map<String, Object> condition);
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -1,5 +1,7 @@
 package com.issuetracker.domain.issue;
 
+import com.issuetracker.domain.issue.request.IssueSearchCondition;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
@@ -74,5 +76,17 @@ public class IssueService {
         issue.deleteMilestone();
 
         return issueRepository.save(issue);
+    }
+
+    public List<Issue> getIssueByCondition(IssueSearchCondition condition) {
+        Map<String, Object> conditionMap = new HashMap<>();
+
+        conditionMap.put("author", condition.getAuthor());
+        conditionMap.put("isOpen", condition.isOpen());
+        conditionMap.put("milestoneId", condition.getMilestoneId());
+        conditionMap.put("labelIds", condition.getLabelIds());
+        conditionMap.put("title", condition.getTitle());
+
+        return issueMapper.findByCondition(conditionMap);
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueSearchCondition.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueSearchCondition.java
@@ -1,0 +1,42 @@
+package com.issuetracker.domain.issue.request;
+
+import com.issuetracker.domain.issue.util.IssueQueryParser;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class IssueSearchCondition {
+
+    private String author;
+    private List<String> labelIds;
+    private String milestoneId;
+    private boolean isOpen = true;
+    private List<String> assignees;
+    private String title;
+
+    public static IssueSearchCondition of(String requestQueryString) {
+        List<String> queryString = IssueQueryParser.parseQueryString(requestQueryString);
+
+        String issueTitle = IssueQueryParser.parseIssueTitle(queryString);
+        String author = IssueQueryParser.parseAuthor(queryString);
+        List<String> labelIds = IssueQueryParser.parseLabels(queryString);
+        String milestone = IssueQueryParser.parseMilestone(queryString);
+        List<String> assignees = IssueQueryParser.parseAssignees(queryString);
+        boolean isOpen = IssueQueryParser.parseOpenStatus(queryString);
+
+        return IssueSearchCondition.builder()
+                .author(author)
+                .labelIds(labelIds)
+                .milestoneId(milestone)
+                .isOpen(isOpen)
+                .assignees(assignees)
+                .title(issueTitle)
+                .build();
+    }
+}

--- a/src/main/java/com/issuetracker/domain/issue/response/IssueResponse.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/IssueResponse.java
@@ -28,7 +28,7 @@ public class IssueResponse {
                 .title(issue.getTitle())
                 .isOpen(issue.isOpen())
                 .labelNames(convertToLabelNames(issue.getIssueLabels()))
-                .milestoneName(issue.getMilestoneRef().getId())
+                .milestoneName(issue.getMilestoneRef() == null ? null : issue.getMilestoneRef().getId())
                 .build();
     }
 

--- a/src/main/java/com/issuetracker/domain/issue/util/IssueQueryParser.java
+++ b/src/main/java/com/issuetracker/domain/issue/util/IssueQueryParser.java
@@ -1,0 +1,102 @@
+package com.issuetracker.domain.issue.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum IssueQueryParser {
+
+    QUERY_STRING_PATTERN(Pattern.compile("(is:open|is:closed|label:[^\"]\\S+|label:\".*?\"|author:[^\"]\\S+|author:\".*?\"|milestone:[^\"]\\S+|milestone:\".*?\"|\\S+)")),
+    ISSUE_TITLE_PATTERN(Pattern.compile("\\b(?!is:open\\b|is:closed\\b|label:.+\\b|milestone:.+\\b|author:.+\\b|assignee:.+\\b)(\\S+)")),
+    AUTHOR_PATTERN(Pattern.compile("(?i)author:\"?([^\"]+)")),
+    LABELS_PATTERN(Pattern.compile("(?i)label:\"?([^\"]+)")),
+    MILESTONE_PATTERN(Pattern.compile("(?i)milestone:\"?([^\"]+)")),
+    ASSIGNEE_PATTERN(Pattern.compile("(?i)assignee:\"?([^\"]+)")),
+    OPEN_STATUS_PATTERN(Pattern.compile("(?i)is:(open|closed)"));
+
+    private static final int MATCH_INDEX = 1;
+    private static final String SPACE = " ";
+    private static final BiFunction<Pattern, String, Matcher> MATCHER_CONVERTER = Pattern::matcher;
+    private final Pattern pattern;
+
+    public static List<String> parseQueryString(String requestQueryString) {
+        List<String> queryString = new ArrayList<>();
+
+        Matcher queryStringMatcher = QUERY_STRING_PATTERN.pattern.matcher(requestQueryString);
+
+        while (queryStringMatcher.find()) {
+            queryString.add(queryStringMatcher.group(MATCH_INDEX));
+        }
+
+        return queryString;
+    }
+
+    public static String parseIssueTitle(List<String> queryString) {
+        return queryString.stream()
+                .filter(str -> MATCHER_CONVERTER.apply(ISSUE_TITLE_PATTERN.pattern, str).matches())
+                .map(str -> {
+                    Matcher matcher = MATCHER_CONVERTER.apply(ISSUE_TITLE_PATTERN.pattern, str);
+                    return matcher.find() ? matcher.group(MATCH_INDEX) : "";
+                })
+                .collect(Collectors.joining(SPACE));
+    }
+
+    public static String parseAuthor(List<String> queryString) {
+        return queryString.stream()
+                .filter(str -> MATCHER_CONVERTER.apply(AUTHOR_PATTERN.pattern, str).find())
+                .map(str -> {
+                    Matcher matcher = MATCHER_CONVERTER.apply(AUTHOR_PATTERN.pattern, str);
+                    return matcher.find() ? matcher.group(MATCH_INDEX) : "";
+                })
+                .findAny()
+                .orElse(null);
+    }
+
+    public static List<String> parseLabels(List<String> queryString) {
+        return queryString.stream()
+                .filter(str -> MATCHER_CONVERTER.apply(LABELS_PATTERN.pattern, str).find())
+                .map(str -> {
+                    Matcher matcher = MATCHER_CONVERTER.apply(LABELS_PATTERN.pattern, str);
+                    return matcher.find() ? matcher.group(MATCH_INDEX) : "";
+                })
+                .toList();
+    }
+
+    public static String parseMilestone(List<String> queryString) {
+        return queryString.stream()
+                .filter(str -> MATCHER_CONVERTER.apply(MILESTONE_PATTERN.pattern, str).find())
+                .map(str -> {
+                    Matcher matcher = MATCHER_CONVERTER.apply(MILESTONE_PATTERN.pattern, str);
+                    return matcher.find() ? matcher.group(MATCH_INDEX) : "";
+                })
+                .findAny()
+                .orElse(null);
+    }
+
+    public static List<String> parseAssignees(List<String> queryString) {
+        return queryString.stream()
+                .filter(str -> MATCHER_CONVERTER.apply(ASSIGNEE_PATTERN.pattern, str).find())
+                .map(str -> {
+                    Matcher matcher = MATCHER_CONVERTER.apply(ASSIGNEE_PATTERN.pattern, str);
+                    return matcher.find() ? matcher.group(MATCH_INDEX) : "";
+                })
+                .toList();
+    }
+
+    public static boolean parseOpenStatus(List<String> queryString) {
+        return queryString.stream()
+                .filter(str -> MATCHER_CONVERTER.apply(OPEN_STATUS_PATTERN.pattern, str).matches())
+                .map(str -> {
+                    Matcher matcher = MATCHER_CONVERTER.apply(OPEN_STATUS_PATTERN.pattern, str);
+                    return matcher.find() ? matcher.group(MATCH_INDEX) : "";
+                })
+                .map(status -> status.equalsIgnoreCase("open"))
+                .findAny()
+                .orElse(true);
+    }
+}

--- a/src/main/java/com/issuetracker/domain/milestone/MilestoneMapper.java
+++ b/src/main/java/com/issuetracker/domain/milestone/MilestoneMapper.java
@@ -1,10 +1,12 @@
 package com.issuetracker.domain.milestone;
 
-import org.apache.ibatis.annotations.Mapper;
-
 import java.util.Map;
+import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface MilestoneMapper {
+
     void update(Map<String, Object> requestMap);
+
+    String findById(String id);
 }

--- a/src/main/java/com/issuetracker/domain/milestone/argumentresolver/MilestoneIdArgumentResolver.java
+++ b/src/main/java/com/issuetracker/domain/milestone/argumentresolver/MilestoneIdArgumentResolver.java
@@ -21,7 +21,7 @@ public class MilestoneIdArgumentResolver implements HandlerMethodArgumentResolve
 
         String pathVariableName = parameter.getParameterAnnotation(MilestoneId.class).value();
 
-        if (pathVariableName.isEmpty()) {
+        if (!pathVariableName.isEmpty()) {
             pathVariableName = parameter.getParameterName();
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ mybatis:
   mapper-locations: classpath:mapper/**/*.xml
   configuration:
     map-underscore-to-camel-case: true
+    default-enum-type-handler: com.issuetracker.domain.issue.AggregateReferenceTypeHandler
 
 # logging
 logging:

--- a/src/main/resources/mapper/issue/Issue.xml
+++ b/src/main/resources/mapper/issue/Issue.xml
@@ -16,4 +16,42 @@
         WHERE ISSUE_ID = #{issueId}
     </update>
 
+    <resultMap id="IssueResultMap" type="com.issuetracker.domain.issue.Issue">
+        <id property="id" column="ISSUE_ID" />
+        <result property="memberId" column="MEMBER_ID" />
+        <result property="isOpen" column="IS_OPEN" />
+        <result property="title" column="TITLE" />
+        <result property="milestoneRef" column="MILESTONE_ID" typeHandler="com.issuetracker.domain.issue.AggregateReferenceTypeHandler"/>
+        <collection property="issueLabels" column="ISSUE_ID" javaType="java.util.Set" ofType="com.issuetracker.domain.issue.IssueLabel"
+                    select="com.issuetracker.domain.issue.IssueLabelMapper.findByIssueId"/>
+    </resultMap>
+
+    <select id="findByCondition" parameterType="Map" resultMap="IssueResultMap">
+        SELECT I.* FROM ISSUE I
+        <where>
+            <if test="author != null and author != ''">
+                I.MEMBER_ID = #{author}
+            </if>
+            <if test="milestoneId != null and milestoneId != ''">
+                AND I.MILESTONE_ID = #{milestoneId}
+            </if>
+            <if test="labelIds != null and labelIds.size() > 0">
+                AND EXISTS (
+                    SELECT 1 FROM ISSUE_LABEL IL
+                    WHERE IL.ISSUE_ID = I.ISSUE_ID
+                    AND IL.LABEL_ID IN
+                    <foreach item="labelId" index="index" collection="labelIds" open="(" separator="," close=")">
+                        #{labelId}
+                    </foreach>
+                    )
+            </if>
+            <if test="title != null and title != ''">
+                AND I.TITLE LIKE CONCAT('%', #{title}, '%')
+            </if>
+            <if test="isOpen != null">
+                AND I.IS_OPEN = #{isOpen}
+            </if>
+        </where>
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/issue/issueLabel.xml
+++ b/src/main/resources/mapper/issue/issueLabel.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.issuetracker.domain.issue.IssueLabelMapper">
+
+    <select id="findByIssueId" parameterType="Long" resultType="com.issuetracker.domain.issue.IssueLabel">
+        SELECT * FROM ISSUE_LABEL WHERE ISSUE_ID = #{issueId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/milestone/milestone.xml
+++ b/src/main/resources/mapper/milestone/milestone.xml
@@ -18,4 +18,9 @@
         </set>
         WHERE MILESTONE_ID = #{milestoneId}
     </update>
+
+    <select id="findById" parameterType="String" resultType="String">
+        SELECT MILESTONE_ID FROM MILESTONE WHERE MILESTONE_ID = #{milestoneId}
+    </select>
+
 </mapper>

--- a/src/test/java/com/issuetracker/domain/issue/argumentresolver/IssueQueryParserTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/argumentresolver/IssueQueryParserTest.java
@@ -1,0 +1,90 @@
+package com.issuetracker.domain.issue.argumentresolver;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.issuetracker.domain.issue.util.IssueQueryParser;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class IssueQueryParserTest {
+
+    private static final String QUERY_STRING = "is:closed 검색 기능 label:bug label:\"bug fix\" author:yelly milestone:\"기능 개발\"";
+
+    @Test
+    @DisplayName("쿼리 스트링을 파싱하면 is:closed 와 같이 지정한 검색 키워드로 파싱할 수 있다")
+    void parseQueryString() {
+        // when
+        List<String> parsedQueryString = IssueQueryParser.parseQueryString(QUERY_STRING);
+
+        // then
+        assertThat(parsedQueryString).contains(
+                "is:closed", "검색", "기능", "label:bug", "label:\"bug fix\"", "author:yelly"
+        );
+    }
+
+    @Test
+    @DisplayName("파싱된 쿼리 스트링에서 '검색 기능' 이라는 이슈 타이틀을 파싱할 수 있다")
+    void parseIssueTitle() {
+        // given
+        List<String> parsedQueryString = IssueQueryParser.parseQueryString(QUERY_STRING);
+
+        // when
+        String issueTitle = IssueQueryParser.parseIssueTitle(parsedQueryString);
+
+        // then
+        assertThat(issueTitle).isEqualTo("검색 기능");
+    }
+
+    @Test
+    @DisplayName("파싱된 쿼리 스트링에서 작성자 'yelly' 를 파싱할 수 있다")
+    void parseAuthor() {
+        // given
+        List<String> parsedQueryString = IssueQueryParser.parseQueryString(QUERY_STRING);
+
+        // when
+        String author = IssueQueryParser.parseAuthor(parsedQueryString);
+
+        // then
+        assertThat(author).isEqualTo("yelly");
+    }
+
+    @Test
+    @DisplayName("파싱된 쿼리 스트링에서 레이블 'bug', 'bug fix' 를 파싱할 수 있다")
+    void parseLabels() {
+        // given
+        List<String> parsedQueryString = IssueQueryParser.parseQueryString(QUERY_STRING);
+
+        // when
+        List<String> labels = IssueQueryParser.parseLabels(parsedQueryString);
+
+        // then
+        assertThat(labels).contains("bug", "bug fix");
+    }
+
+    @Test
+    @DisplayName("파싱된 쿼리 스트링에서 '기능 개발'이라는 마일스톤 아이디를 파싱할 수 있다")
+    void parseMilestone() {
+        // given
+        List<String> parsedQueryString = IssueQueryParser.parseQueryString(QUERY_STRING);
+
+        // when
+        String milestone = IssueQueryParser.parseMilestone(parsedQueryString);
+
+        // then
+        assertThat(milestone).isEqualTo("기능 개발");
+    }
+
+    @Test
+    @DisplayName("파싱된 쿼리 스트링에서 이슈의 상태인 'closed' 라는 이슈의 열린 상태를 파싱할 수 있다")
+    void parseOpenStatus() {
+        // given
+        List<String> parsedQueryString = IssueQueryParser.parseQueryString(QUERY_STRING);
+
+        // when
+        boolean isOpen = IssueQueryParser.parseOpenStatus(parsedQueryString);
+
+        // then
+        assertThat(isOpen).isFalse();
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request
- 이슈에 대한 필터 및 검색 기능에 대한 기능을 구현하여 merge 요청합니다.

## 구현 내용
- 이슈에 대한 필터 및 검색 API 에 대한 기능
  - '작성자, 마일스톤, 레이블(들), 이슈 상태, 검색어'의 유무에 따른 이슈 조회 기능 구현
  - MyBatis 로 동적 쿼리 처리를 통해 조건별 응답 확인 완료

## 관련 이슈
close #35 
