### PR TITLE
Feat/#38 예외처리 로직  구현

### DIFF
--- a/src/main/java/com/issuetracker/domain/comment/CommentService.java
+++ b/src/main/java/com/issuetracker/domain/comment/CommentService.java
@@ -7,9 +7,11 @@ import com.issuetracker.domain.issue.IssueRepository;
 import com.issuetracker.global.exception.issue.IssueNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CommentService {
 
     private final IssueRepository issueRepository;

--- a/src/main/java/com/issuetracker/domain/comment/CommentService.java
+++ b/src/main/java/com/issuetracker/domain/comment/CommentService.java
@@ -4,6 +4,7 @@ import com.issuetracker.domain.comment.request.CommentCreateRequest;
 import com.issuetracker.domain.comment.request.CommentUpdateRequest;
 import com.issuetracker.domain.issue.Issue;
 import com.issuetracker.domain.issue.IssueRepository;
+import com.issuetracker.global.exception.issue.IssueNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,7 +17,7 @@ public class CommentService {
 
     public Long create(CommentCreateRequest request) {
         Issue issue = issueRepository.findById(request.getIssueId())
-                .orElseThrow(IllegalStateException::new);
+                .orElseThrow(IssueNotFoundException::new);
 
         Comment comment = request.toEntity();
 

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -9,11 +9,14 @@ import org.springframework.stereotype.Service;
 import java.util.Map;
 import com.issuetracker.domain.issue.response.IssueListResponse;
 import com.issuetracker.domain.issue.response.IssueResponse;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class IssueService {
 
     private final IssueRepository issueRepository;
@@ -24,6 +27,7 @@ public class IssueService {
         return savedIssue.getId();
     }
 
+    @Transactional(readOnly = true)
     public IssueDetailResponse getDetail(Long issueId) {
         Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         return IssueDetailResponse.from(issue);
@@ -37,6 +41,7 @@ public class IssueService {
         issueMapper.update(form);
     }
 
+    @Transactional(readOnly = true)
     public IssueListResponse getIssues() {
         List<Issue> issues = issueRepository.findAll();
         return IssueListResponse.of(

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -2,6 +2,7 @@ package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueSearchCondition;
 import java.util.HashMap;
+import com.issuetracker.global.exception.issue.IssueNotFoundException;
 import lombok.RequiredArgsConstructor;
 import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
@@ -24,7 +25,7 @@ public class IssueService {
     }
 
     public IssueDetailResponse getDetail(Long issueId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
+        Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         return IssueDetailResponse.from(issue);
     }
 
@@ -44,35 +45,35 @@ public class IssueService {
     }
 
     public void addLabel(Long issueId, String labelId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
+        Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.addLabel(labelId);
 
         issueRepository.save(issue);
     }
 
     public Issue addLabels(Long issueId, List<String> labelIds) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
+        Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.addLabels(labelIds);
 
         return issueRepository.save(issue);
     }
 
     public Issue deleteLabel(Long issueId, String labelId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
+        Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.deleteLabel(labelId);
 
         return issueRepository.save(issue);
     }
 
     public void assignMilestone(Long issueId, String milestoneId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
+        Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.assignMilestone(milestoneId);
 
         issueRepository.save(issue);
     }
 
     public Issue deleteMilestone(Long issueId) {
-        Issue issue = issueRepository.findById(issueId).orElseThrow(RuntimeException::new);
+        Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.deleteMilestone();
 
         return issueRepository.save(issue);

--- a/src/main/java/com/issuetracker/domain/label/LabelService.java
+++ b/src/main/java/com/issuetracker/domain/label/LabelService.java
@@ -7,6 +7,7 @@ import com.issuetracker.domain.label.response.LabelResponse;
 import com.issuetracker.global.exception.label.LabelDuplicateException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class LabelService {
 
     private final LabelRepository labelRepository;
@@ -32,6 +34,7 @@ public class LabelService {
         return LabelResponse.of(savedLabel);
     }
 
+    @Transactional(readOnly = true)
     public LabelListResponse getLabels() {
         List<Label> labels = labelRepository.findAll();
         return LabelListResponse.of(

--- a/src/main/java/com/issuetracker/domain/label/LabelService.java
+++ b/src/main/java/com/issuetracker/domain/label/LabelService.java
@@ -4,8 +4,8 @@ import com.issuetracker.domain.label.request.LabelCreateRequest;
 import com.issuetracker.domain.label.request.LabelUpdateRequest;
 import com.issuetracker.domain.label.response.LabelListResponse;
 import com.issuetracker.domain.label.response.LabelResponse;
+import com.issuetracker.global.exception.label.LabelDuplicateException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -25,7 +25,7 @@ public class LabelService {
     public LabelResponse create(LabelCreateRequest labelCreateRequest) {
         labelRepository.findById(labelCreateRequest.getLabelId())
                 .ifPresent(label -> {
-                    throw new DuplicateKeyException("이미 존재하는 레이블입니다.");
+                    throw new LabelDuplicateException();
                 });
         Label label = labelCreateRequest.toEntity();
         Label savedLabel = labelRepository.save(label);

--- a/src/main/java/com/issuetracker/domain/milestone/MilestoneService.java
+++ b/src/main/java/com/issuetracker/domain/milestone/MilestoneService.java
@@ -6,6 +6,7 @@ import com.issuetracker.domain.milestone.response.MilestoneListResponse;
 import com.issuetracker.domain.milestone.response.MilestoneResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +15,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MilestoneService {
 
     private final MilestoneRepository milestoneRepository;
@@ -25,6 +27,7 @@ public class MilestoneService {
         return MilestoneResponse.of(savedMilestone);
     }
 
+    @Transactional(readOnly = true)
     public MilestoneListResponse getMilestones(boolean openStatus) {
         List<Milestone> milestones =  milestoneRepository.findMilestonesByIsOpen(openStatus);
         return MilestoneListResponse.of(milestones);
@@ -46,6 +49,7 @@ public class MilestoneService {
         milestoneMapper.update(requestMap);
     }
 
+    @Transactional(readOnly = true)
     public Long count(boolean openStatus) {
         return milestoneRepository.countByIsOpen(openStatus);
     }

--- a/src/main/java/com/issuetracker/domain/milestone/argumentresolver/MilestoneIdArgumentResolver.java
+++ b/src/main/java/com/issuetracker/domain/milestone/argumentresolver/MilestoneIdArgumentResolver.java
@@ -1,18 +1,19 @@
 package com.issuetracker.domain.milestone.argumentresolver;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 public class MilestoneIdArgumentResolver implements HandlerMethodArgumentResolver {
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean hasMilestoneIdAnnotation = parameter.hasParameterAnnotation(MilestoneId.class);
-        boolean hasMilestoneId = String.class.isAssignableFrom(parameter.getParameterType());
-
-        return hasMilestoneIdAnnotation && hasMilestoneId;
+        return parameter.hasParameterAnnotation(MilestoneId.class);
     }
 
     @Override
@@ -27,10 +28,22 @@ public class MilestoneIdArgumentResolver implements HandlerMethodArgumentResolve
 
         String value = webRequest.getParameter(pathVariableName);
 
-        if (value == null || value.isBlank() || value.length() > 30) {
-            throw new IllegalArgumentException("마일스톤 ID는 비어있거나 30자를 넘을 수 없습니다.");
-        }
+        validateMilestoneId(value, pathVariableName, parameter);
 
         return value;
+    }
+
+    private void validateMilestoneId(String value, String pathVariableName, MethodParameter parameter) throws MethodArgumentNotValidException {
+        if (value == null || value.isBlank()) {
+            throwValidationException(parameter, pathVariableName, "마일스톤 ID는 비어있거나 null일 수 없습니다.");
+        } else if (value.length() > 30) {
+            throwValidationException(parameter, pathVariableName, "마일스톤 ID는 30자 이하여야 합니다.");
+        }
+    }
+
+    private void throwValidationException(MethodParameter parameter, String pathVariableName, String errorMessage) throws MethodArgumentNotValidException {
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(pathVariableName, parameter.getParameterType().getName());
+        bindingResult.addError(new ObjectError(pathVariableName, errorMessage));
+        throw new MethodArgumentNotValidException(parameter, bindingResult);
     }
 }

--- a/src/main/java/com/issuetracker/domain/milestone/argumentresolver/MilestoneIdArgumentResolver.java
+++ b/src/main/java/com/issuetracker/domain/milestone/argumentresolver/MilestoneIdArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.issuetracker.domain.milestone.argumentresolver;
 
+import lombok.NonNull;
 import org.springframework.core.MethodParameter;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.ObjectError;
@@ -8,6 +9,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import java.util.Objects;
 
 public class MilestoneIdArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -18,14 +21,15 @@ public class MilestoneIdArgumentResolver implements HandlerMethodArgumentResolve
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+                                  @NonNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
 
-        String pathVariableName = parameter.getParameterAnnotation(MilestoneId.class).value();
+        String pathVariableName = Objects.requireNonNull(parameter.getParameterAnnotation(MilestoneId.class)).value();
 
         if (!pathVariableName.isEmpty()) {
             pathVariableName = parameter.getParameterName();
         }
 
+        assert pathVariableName != null;
         String value = webRequest.getParameter(pathVariableName);
 
         validateMilestoneId(value, pathVariableName, parameter);

--- a/src/main/java/com/issuetracker/global/exception/ErrorResponse.java
+++ b/src/main/java/com/issuetracker/global/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.issuetracker.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final Integer errorCode;
+    private final String errorMessage;
+
+    public ErrorResponse(GlobalException e) {
+        this.errorCode = e.getCode();
+        this.errorMessage = e.getMessage();
+    }
+
+    public ErrorResponse(ExceptionType exceptionType) {
+        this.errorCode = exceptionType.getCode();
+        this.errorMessage = exceptionType.getMessage();
+    }
+}

--- a/src/main/java/com/issuetracker/global/exception/ExceptionType.java
+++ b/src/main/java/com/issuetracker/global/exception/ExceptionType.java
@@ -1,0 +1,82 @@
+package com.issuetracker.global.exception;
+
+import com.issuetracker.global.exception.comment.CommentNotFoundException;
+import com.issuetracker.global.exception.issue.IssueNotFoundException;
+import com.issuetracker.global.exception.label.LabelDuplicateException;
+import com.issuetracker.global.exception.label.LabelNotFoundException;
+import com.issuetracker.global.exception.member.MemberDuplicateException;
+import com.issuetracker.global.exception.member.MemberNotFoundException;
+import com.issuetracker.global.exception.milestone.MilestoneDuplicateException;
+import com.issuetracker.global.exception.milestone.MilestoneNotFoundException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@Getter
+@Slf4j
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ExceptionType {
+
+    /**
+     * Global Exception
+     */
+    UNHANDLED(1000, "알 수 없는 서버 에러가 발생했습니다.", null),
+
+    /**
+     * Auth (2XXX)
+     */
+
+    /**
+     * Member (25XX)
+     */
+    MEMBER_NOT_FOUND(2500, "존재하지 않는 사용자입니다.", MemberNotFoundException.class),
+    MEMBER_ALREADY_EXISTS(2501, "이미 존재하는 사용자입니다.", MemberDuplicateException.class),
+
+    /**
+     * Issue (3XXX)
+     */
+    ISSUE_NOT_FOUND(3000, "존재하지 않는 이슈입니다.", IssueNotFoundException.class),
+
+    /**
+     * Label (4XXX)
+     */
+    LABEL_NOT_FOUND(4000, "존재하지 않는 레이블입니다.", LabelNotFoundException.class),
+    LABEL_ALREADY_EXISTS(4001, "이미 존재하는 레이블입니다.", LabelDuplicateException.class),
+
+    /**
+     * Milestone (5XXX)
+     */
+    MILESTONE_NOT_FOUND(5001, "존재하지 않는 마일스톤입니다.", MilestoneNotFoundException.class),
+    MILESTONE_ALREADY_EXISTS(5002, "이미 존재하는 마일스톤입니다.", MilestoneDuplicateException.class),
+
+    /**
+     * Comment (6XXX)
+     */
+    COMMENT_NOT_FOUND(6001, "존재하지 않는 댓글입니다.", CommentNotFoundException.class),
+
+    /**
+     * Search (7XXX)
+     */
+    ;
+
+    private final Integer code;
+    private final String message;
+    private final Class<? extends Exception> type;
+
+    public static Optional<ExceptionType> of(Class<? extends Exception> clazz) {
+        Optional<ExceptionType> exceptionType = Arrays.stream(values())
+                .filter(ex -> ex.getType() != null && ex.getType().equals(clazz))
+                .findFirst();
+
+        if(exceptionType.isEmpty()) {
+            log.error("정의되지 않은 예외가 발생했습니다. : {}", clazz);
+        }
+
+        return exceptionType;
+    }
+
+}

--- a/src/main/java/com/issuetracker/global/exception/ExceptionType.java
+++ b/src/main/java/com/issuetracker/global/exception/ExceptionType.java
@@ -12,6 +12,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import java.util.Arrays;
 import java.util.Optional;
@@ -25,6 +26,7 @@ public enum ExceptionType {
      * Global Exception
      */
     UNHANDLED(1000, "알 수 없는 서버 에러가 발생했습니다.", null),
+    METHOD_ARGUMENT_NOT_VALID(1001, "요청 데이터가 유효하지 않습니다.", MethodArgumentNotValidException.class),
 
     /**
      * Auth (2XXX)

--- a/src/main/java/com/issuetracker/global/exception/GlobalException.java
+++ b/src/main/java/com/issuetracker/global/exception/GlobalException.java
@@ -1,0 +1,50 @@
+package com.issuetracker.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+    private final Throwable cause;
+
+    public GlobalException(HttpStatus httpStatus) {
+        ExceptionType exceptionType = getExceptionType();
+        this.httpStatus = httpStatus;
+        this.code = exceptionType.getCode();
+        this.message = exceptionType.getMessage();
+        this.cause = null;
+    }
+
+    public GlobalException(HttpStatus httpStatus, String message) {
+        ExceptionType exceptionType = getExceptionType();
+        this.httpStatus = httpStatus;
+        this.code = exceptionType.getCode();
+        this.message = message;
+        this.cause = null;
+    }
+
+    public GlobalException(HttpStatus httpStatus, Throwable cause) {
+        ExceptionType exceptionType = getExceptionType();
+        this.httpStatus = httpStatus;
+        this.code = exceptionType.getCode();
+        this.message = exceptionType.getMessage();
+        this.cause = cause;
+    }
+
+    public GlobalException(HttpStatus httpStatus, String message, Throwable cause) {
+        ExceptionType exceptionType = getExceptionType();
+        this.httpStatus = httpStatus;
+        this.code = exceptionType.getCode();
+        this.message = message;
+        this.cause = cause;
+    }
+
+    private ExceptionType getExceptionType() {
+        return ExceptionType.of(this.getClass()).orElse(ExceptionType.UNHANDLED);
+    }
+
+}

--- a/src/main/java/com/issuetracker/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/issuetracker/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -33,8 +34,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException ex, HttpHeaders headers,
-            HttpStatusCode status, WebRequest request) {
+            @NonNull MethodArgumentNotValidException ex, @NonNull HttpHeaders headers,
+            @NonNull HttpStatusCode status, @NonNull WebRequest request) {
         ExceptionType methodArgumentNotValid = METHOD_ARGUMENT_NOT_VALID;
         log.error(getExceptionStackTrace(ex));
 
@@ -56,7 +57,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
-            Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+            @NonNull Exception ex, @Nullable Object body, @NonNull HttpHeaders headers, @NonNull HttpStatusCode statusCode, @NonNull WebRequest request) {
         log.error("[Spring MVC Exception] {}", getExceptionStackTrace(ex));
 
         ExceptionType exceptionType = ExceptionType.of(ex.getClass()).orElse(ExceptionType.UNHANDLED);

--- a/src/main/java/com/issuetracker/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/issuetracker/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.issuetracker.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static com.issuetracker.global.exception.ExceptionType.METHOD_ARGUMENT_NOT_VALID;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(GlobalException e){
+        log.error(getExceptionStackTrace(e));
+
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers,
+            HttpStatusCode status, WebRequest request) {
+        ExceptionType methodArgumentNotValid = METHOD_ARGUMENT_NOT_VALID;
+        log.error(getExceptionStackTrace(ex));
+
+        List<ValidationErrorDetails> validationErrorDetails = ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> new ValidationErrorDetails(
+                        fieldError.getField(),
+                        fieldError.getCode(),
+                        fieldError.getDefaultMessage()
+                )).toList();
+
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new ValidationErrorResponse(
+                        methodArgumentNotValid.getCode(),
+                        methodArgumentNotValid.getMessage(),
+                        validationErrorDetails
+                ));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        log.error("[Spring MVC Exception] {}", getExceptionStackTrace(ex));
+
+        ExceptionType exceptionType = ExceptionType.of(ex.getClass()).orElse(ExceptionType.UNHANDLED);
+        return ResponseEntity
+                .status(statusCode)
+                .body(new ErrorResponse(exceptionType));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        log.error("[UnHandled Exception] {}", getExceptionStackTrace(ex));
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(
+                        ExceptionType.UNHANDLED.getCode(),
+                        ExceptionType.UNHANDLED.getMessage() + " " + ex.getMessage()
+                ));
+    }
+
+    private String getExceptionStackTrace(Exception e) {
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+        return String.valueOf(stringWriter);
+    }
+}

--- a/src/main/java/com/issuetracker/global/exception/ValidationErrorDetails.java
+++ b/src/main/java/com/issuetracker/global/exception/ValidationErrorDetails.java
@@ -1,0 +1,13 @@
+package com.issuetracker.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ValidationErrorDetails {
+
+    private final String field;
+    private final String checkedBy;
+    private final String errorMessage;
+}

--- a/src/main/java/com/issuetracker/global/exception/ValidationErrorResponse.java
+++ b/src/main/java/com/issuetracker/global/exception/ValidationErrorResponse.java
@@ -1,0 +1,15 @@
+package com.issuetracker.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ValidationErrorResponse {
+
+    private final Integer errorCode;
+    private final String errorMessage;
+    List<ValidationErrorDetails> errors;
+}

--- a/src/main/java/com/issuetracker/global/exception/comment/CommentNotFoundException.java
+++ b/src/main/java/com/issuetracker/global/exception/comment/CommentNotFoundException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.comment;
+
+import com.issuetracker.global.exception.common.NotFoundException;
+
+public class CommentNotFoundException extends NotFoundException {
+}

--- a/src/main/java/com/issuetracker/global/exception/common/BadRequestException.java
+++ b/src/main/java/com/issuetracker/global/exception/common/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.issuetracker.global.exception.common;
+
+import com.issuetracker.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends GlobalException {
+    public BadRequestException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+
+    public BadRequestException(String errorMessage) {
+        super(HttpStatus.BAD_REQUEST, errorMessage);
+    }
+}

--- a/src/main/java/com/issuetracker/global/exception/common/ConflictException.java
+++ b/src/main/java/com/issuetracker/global/exception/common/ConflictException.java
@@ -1,0 +1,15 @@
+package com.issuetracker.global.exception.common;
+
+import com.issuetracker.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends GlobalException {
+
+    public ConflictException() {
+        super(HttpStatus.CONFLICT);
+    }
+
+    public ConflictException(String message) {
+        super(HttpStatus.CONFLICT, message);
+    }
+}

--- a/src/main/java/com/issuetracker/global/exception/common/InternalServerErrorException.java
+++ b/src/main/java/com/issuetracker/global/exception/common/InternalServerErrorException.java
@@ -1,0 +1,24 @@
+package com.issuetracker.global.exception.common;
+
+import com.issuetracker.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class InternalServerErrorException extends GlobalException {
+
+    public InternalServerErrorException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    public InternalServerErrorException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message);
+    }
+
+    public InternalServerErrorException(Throwable cause) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, cause);
+    }
+
+    public InternalServerErrorException(String message, Throwable cause) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, message, cause);
+    }
+
+}

--- a/src/main/java/com/issuetracker/global/exception/common/NotFoundException.java
+++ b/src/main/java/com/issuetracker/global/exception/common/NotFoundException.java
@@ -1,0 +1,15 @@
+package com.issuetracker.global.exception.common;
+
+import com.issuetracker.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends GlobalException {
+
+    public NotFoundException() {
+        super(HttpStatus.NOT_FOUND);
+    }
+
+    public NotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+}

--- a/src/main/java/com/issuetracker/global/exception/issue/IssueDuplicationException.java
+++ b/src/main/java/com/issuetracker/global/exception/issue/IssueDuplicationException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.issue;
+
+import com.issuetracker.global.exception.common.ConflictException;
+
+public class IssueDuplicationException extends ConflictException {
+}

--- a/src/main/java/com/issuetracker/global/exception/issue/IssueNotFoundException.java
+++ b/src/main/java/com/issuetracker/global/exception/issue/IssueNotFoundException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.issue;
+
+import com.issuetracker.global.exception.common.NotFoundException;
+
+public class IssueNotFoundException extends NotFoundException {
+}

--- a/src/main/java/com/issuetracker/global/exception/label/LabelDuplicateException.java
+++ b/src/main/java/com/issuetracker/global/exception/label/LabelDuplicateException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.label;
+
+import com.issuetracker.global.exception.common.ConflictException;
+
+public class LabelDuplicateException extends ConflictException {
+}

--- a/src/main/java/com/issuetracker/global/exception/label/LabelNotFoundException.java
+++ b/src/main/java/com/issuetracker/global/exception/label/LabelNotFoundException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.label;
+
+import com.issuetracker.global.exception.common.NotFoundException;
+
+public class LabelNotFoundException extends NotFoundException {
+}

--- a/src/main/java/com/issuetracker/global/exception/member/MemberDuplicateException.java
+++ b/src/main/java/com/issuetracker/global/exception/member/MemberDuplicateException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.member;
+
+import com.issuetracker.global.exception.common.ConflictException;
+
+public class MemberDuplicateException extends ConflictException {
+}

--- a/src/main/java/com/issuetracker/global/exception/member/MemberNotFoundException.java
+++ b/src/main/java/com/issuetracker/global/exception/member/MemberNotFoundException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.member;
+
+import com.issuetracker.global.exception.common.NotFoundException;
+
+public class MemberNotFoundException extends NotFoundException {
+}

--- a/src/main/java/com/issuetracker/global/exception/milestone/MilestoneDuplicateException.java
+++ b/src/main/java/com/issuetracker/global/exception/milestone/MilestoneDuplicateException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.milestone;
+
+import com.issuetracker.global.exception.common.ConflictException;
+
+public class MilestoneDuplicateException extends ConflictException {
+}

--- a/src/main/java/com/issuetracker/global/exception/milestone/MilestoneNotFoundException.java
+++ b/src/main/java/com/issuetracker/global/exception/milestone/MilestoneNotFoundException.java
@@ -1,0 +1,6 @@
+package com.issuetracker.global.exception.milestone;
+
+import com.issuetracker.global.exception.common.NotFoundException;
+
+public class MilestoneNotFoundException extends NotFoundException {
+}


### PR DESCRIPTION
# 🚀 Pull Request

## 구현 내용
### GlobalException
RuntimeException을 상속하는 GlobalException 클래스를 만들었습니다. 해당 클래스는 http 상태코드, 에러코드, 에러메시지, Throwable을 필드로 가집니다.
해당 클래스를 상속받는 예외 클래스들을 만들어 확장하고 있습니다. 바로 아래 하위 클래스로 NotFoundException, ConflictException, BadRequestException, InternalServerErrorException이 있고, 해당 클래스들을 상속받는 다른 클래스들(ex. CommentNotFoundException)로 예외 클래스들을 확장합니다.

### ExceptionType
enum 클래스인 ExceptionType은 에러 코드, 메시지, 타입을 필드로 가집니다. class타입을 파라미터로 받아 해당 클래스에 해당하는 enum 상수를 찾는 of라는 static 메서드도 가지고 있어, GlobalException의 생성자에서 이 메서드를 활용해 해당 클래스의 ExceptionType을 찾아 필드를 초기화합니다.

### GlobalExceptionHandler
GlobalExceptionHandler로 예외 발생시 전역적으로 캐치해 해당 핸들러 클래스 내 메서드로 해결하도록 구현했습니다. 
직접 선언한 GlobalException의 자식 예외들을 잡는 핸들러 메서드, 클라이언트 요청 데이터가 잘못되었을 때 발생하는 MethodArgumentNotValidException을 잡는 핸들러 메서드, Spring MVC에서 제공하는 예외를 처리하는 메서드, 그 외 모든 Exception 하위 예외들을 잡는 핸들러 메서드가 있습니다.
각각 해당하는 예외를 잡는 경우 ErrorResponse를 생성해 응답하며, 콘솔에 로그를 남깁니다.

## 고민 사항
구조가 복잡해 수정의 여지가 있어 보입니다.
개선사항 제안해주실 거 있다면 말씀해주세요~

## 기타
이 브랜치에서 Transactional에 대한 처리도 함께 했습니다.
repository 메서드를 사용하는 Service 클래스 메서드에 `@Transactional` 어노테이션을 붙여 하나의 메서드에 대해 트랜잭션을 보장하도록 했습니다.
이렇게 해서 중간에 오류가 발생해도 데이터 무결성을 유지하고, 애플리케이션의 데이터 처리를 더 안전하게 관리할 수 있습니다.

## 관련 이슈
close #38 
