### PR TITLE
Feat/#44 이슈 목록 조회, 이슈 필터링, 이슈 상태 변경 구현

### DIFF
--- a/src/main/java/com/issuetracker/domain/issue/Issue.java
+++ b/src/main/java/com/issuetracker/domain/issue/Issue.java
@@ -47,6 +47,11 @@ public class Issue extends BaseDateTime {
     @Column("MILESTONE_ID")
     private AggregateReference<Milestone, String> milestoneRef;
 
+    public Issue updateStatus(boolean status) {
+        this.isOpen = status;
+        return this;
+    }
+
     public void addComment(Comment comment) {
         comment.initBaseDateTime();
         this.comments.add(comment);

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -1,18 +1,16 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueCreateRequest;
-import com.issuetracker.domain.issue.request.IssueSearchCondition;
 import com.issuetracker.domain.issue.request.LabelAddRequest;
 import com.issuetracker.domain.issue.request.MilestoneAssignRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.issue.response.IssueDetailsResponse;
 import com.issuetracker.domain.issue.response.IssueListResponse;
-import com.issuetracker.domain.issue.response.IssueResponse;
+import com.issuetracker.domain.issue.response.SimpleIssue;
 import jakarta.validation.Valid;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -75,14 +73,23 @@ public class IssueController {
     }
 
     @GetMapping
-    public ResponseEntity<?> getIssuesByCondition(@RequestParam("q") String condition) {
-        List<Issue> issues = issueService.getIssueByCondition(IssueSearchCondition.of(condition));
-
-        List<IssueResponse> issueResponses = issues.stream()
-                .map(IssueResponse::of)
-                .collect(Collectors.toList());
+    public ResponseEntity<IssueListResponse> getIssues() {
+        List<SimpleIssue> issues = issueService.getIssues();
 
         return ResponseEntity
-                .ok(IssueListResponse.of(issueResponses));
+                .ok(IssueListResponse.from(issues));
     }
+
+    // TODO: 필터링
+//    @GetMapping
+//    public ResponseEntity<?> getIssuesByCondition(@RequestParam("q") String condition) {
+//        List<Issue> issues = issueService.getIssueByCondition(IssueSearchCondition.of(condition));
+//
+//        List<IssuePreviewResponse> issuePreviewRespons = issues.stream()
+//                .map(IssuePreviewResponse::from)
+//                .collect(Collectors.toList());
+//
+//        return ResponseEntity
+//                .ok(IssueListResponse.of(issuePreviewRespons));
+//    }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -7,10 +7,9 @@ import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.issue.response.IssueDetailsResponse;
 import com.issuetracker.domain.issue.response.IssueListResponse;
 import com.issuetracker.domain.issue.response.IssueStatusResponse;
-import com.issuetracker.domain.issue.response.SimpleIssue;
+import com.issuetracker.domain.issue.request.*;
 import jakarta.validation.Valid;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -83,9 +82,7 @@ public class IssueController {
     @GetMapping
     public ResponseEntity<IssueListResponse> getIssuesByCondition(
             @RequestParam(required = false, defaultValue ="is:open", name = "q") String condition) {
-        List<SimpleIssue> issues = issueService.getIssuesByCondition(IssueSearchCondition.of(condition));
-
-        return ResponseEntity
-                .ok(IssueListResponse.from(issues));
+        return ResponseEntity.ok(
+                issueService.getIssuesByCondition(IssueSearchCondition.of(condition)));
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -6,6 +6,7 @@ import com.issuetracker.domain.issue.request.MilestoneAssignRequest;
 import com.issuetracker.domain.issue.request.IssueUpdateRequest;
 import com.issuetracker.domain.issue.response.IssueDetailsResponse;
 import com.issuetracker.domain.issue.response.IssueListResponse;
+import com.issuetracker.domain.issue.response.IssueStatusResponse;
 import com.issuetracker.domain.issue.response.SimpleIssue;
 import jakarta.validation.Valid;
 import java.util.HashMap;
@@ -70,6 +71,14 @@ public class IssueController {
         return ResponseEntity
                 .ok()
                 .build();
+    }
+
+    @PatchMapping("/{issueId}")
+    public ResponseEntity<IssueStatusResponse> updateStatus(
+            @PathVariable("issueId") Long issueId, @RequestParam("isOpen") boolean openStatus) {
+        Issue issue = issueService.updateStatus(issueId, openStatus);
+        IssueStatusResponse response = IssueStatusResponse.from(issue);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -75,10 +75,9 @@ public class IssueController {
 
     @PatchMapping("/status")
     public ResponseEntity<IssueStatusResponse> updateStatus(
-            @RequestParam("issueId") Long issueId, @RequestParam("isOpen") boolean openStatus) {
-        Issue issue = issueService.updateStatus(issueId, openStatus);
-        IssueStatusResponse response = IssueStatusResponse.from(issue);
-        return ResponseEntity.ok(response);
+            @RequestParam("issueId") String issueIdString, @RequestParam("isOpen") boolean openStatus) {
+        issueService.updateStatus(issueIdString, openStatus);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -73,23 +73,10 @@ public class IssueController {
     }
 
     @GetMapping
-    public ResponseEntity<IssueListResponse> getIssues() {
-        List<SimpleIssue> issues = issueService.getIssues();
+    public ResponseEntity<IssueListResponse> getIssuesByCondition(@RequestParam("q") String condition) {
+        List<SimpleIssue> issues = issueService.getIssuesByCondition(IssueSearchCondition.of(condition));
 
         return ResponseEntity
                 .ok(IssueListResponse.from(issues));
     }
-
-    // TODO: 필터링
-//    @GetMapping
-//    public ResponseEntity<?> getIssuesByCondition(@RequestParam("q") String condition) {
-//        List<Issue> issues = issueService.getIssueByCondition(IssueSearchCondition.of(condition));
-//
-//        List<IssuePreviewResponse> issuePreviewRespons = issues.stream()
-//                .map(IssuePreviewResponse::from)
-//                .collect(Collectors.toList());
-//
-//        return ResponseEntity
-//                .ok(IssueListResponse.of(issuePreviewRespons));
-//    }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -73,9 +73,9 @@ public class IssueController {
                 .build();
     }
 
-    @PatchMapping("/{issueId}")
+    @PatchMapping("/status")
     public ResponseEntity<IssueStatusResponse> updateStatus(
-            @PathVariable("issueId") Long issueId, @RequestParam("isOpen") boolean openStatus) {
+            @RequestParam("issueId") Long issueId, @RequestParam("isOpen") boolean openStatus) {
         Issue issue = issueService.updateStatus(issueId, openStatus);
         IssueStatusResponse response = IssueStatusResponse.from(issue);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/issuetracker/domain/issue/IssueController.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueController.java
@@ -73,7 +73,8 @@ public class IssueController {
     }
 
     @GetMapping
-    public ResponseEntity<IssueListResponse> getIssuesByCondition(@RequestParam("q") String condition) {
+    public ResponseEntity<IssueListResponse> getIssuesByCondition(
+            @RequestParam(required = false, defaultValue ="is:open", name = "q") String condition) {
         List<SimpleIssue> issues = issueService.getIssuesByCondition(IssueSearchCondition.of(condition));
 
         return ResponseEntity

--- a/src/main/java/com/issuetracker/domain/issue/IssueMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueMapper.java
@@ -1,6 +1,5 @@
 package com.issuetracker.domain.issue;
 
-import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.Map;
@@ -9,6 +8,4 @@ import java.util.Map;
 public interface IssueMapper {
 
     void update(Map<String, Object> requestMap);
-
-    List<Issue> findByCondition(Map<String, Object> condition);
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueRepository.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueRepository.java
@@ -13,6 +13,6 @@ public interface IssueRepository extends CrudRepository<Issue, Long> {
     List<Issue> findAll();
 
     @Modifying
-    @Query("UPDATE ISSUE SET IS_OPEN = :openStatus WHERE ISSUE_ID = :issueId")
-    void updateOpenStatus(Long issueId, boolean openStatus);
+    @Query("UPDATE ISSUE SET IS_OPEN = :openStatus WHERE ISSUE_ID IN (:issueIds)")
+    void updateOpenStatus(List<Long> issueIds, boolean openStatus);
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueRepository.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueRepository.java
@@ -1,6 +1,9 @@
 package com.issuetracker.domain.issue;
 
 import java.util.List;
+
+import org.springframework.data.jdbc.repository.query.Modifying;
+import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +11,8 @@ import org.springframework.stereotype.Repository;
 public interface IssueRepository extends CrudRepository<Issue, Long> {
 
     List<Issue> findAll();
+
+    @Modifying
+    @Query("UPDATE ISSUE SET IS_OPEN = :openStatus WHERE ISSUE_ID = :issueId")
+    void updateOpenStatus(Long issueId, boolean openStatus);
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -12,7 +12,6 @@ import com.issuetracker.domain.issue.response.IssueListResponse;
 import com.issuetracker.domain.issue.response.SimpleIssue;
 import com.issuetracker.global.exception.issue.IssueNotFoundException;
 import lombok.RequiredArgsConstructor;
-import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
 import java.util.Map;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -98,7 +98,7 @@ public class IssueService {
         conditionMap.put("isOpen", condition.isOpen());
         conditionMap.put("milestoneId", condition.getMilestoneId());
         conditionMap.put("labelIds", condition.getLabelIds());
-        conditionMap.put("title", condition.getTitle()); // TODO: content 추가
+        conditionMap.put("keyword", condition.getKeyword());
 
         return issueViewMapper.findAllByCondition(conditionMap);
     }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 
 import com.issuetracker.domain.issue.response.IssueDetailsResponse;
 
+import com.issuetracker.domain.issue.response.IssueCount;
+import com.issuetracker.domain.issue.response.IssueListResponse;
 import com.issuetracker.domain.issue.response.SimpleIssue;
 import com.issuetracker.global.exception.issue.IssueNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +18,6 @@ import java.util.Map;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -91,7 +92,7 @@ public class IssueService {
     }
 
     @Transactional(readOnly = true)
-    public List<SimpleIssue> getIssuesByCondition(IssueSearchCondition condition) {
+    public IssueListResponse getIssuesByCondition(IssueSearchCondition condition) {
         Map<String, Object> conditionMap = new HashMap<>();
 
         conditionMap.put("author", condition.getAuthor());
@@ -100,6 +101,9 @@ public class IssueService {
         conditionMap.put("labelIds", condition.getLabelIds());
         conditionMap.put("keyword", condition.getKeyword());
 
-        return issueViewMapper.findAllByCondition(conditionMap);
+        IssueCount issueCount = issueViewMapper.countByCondition(conditionMap);
+        List<SimpleIssue> issues = issueViewMapper.findAllByCondition(conditionMap);
+
+        return IssueListResponse.from(issueCount, issues);
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -43,6 +43,16 @@ public class IssueService {
         issueMapper.update(form);
     }
 
+    public Issue updateStatus(Long issueId, boolean openStatus) {
+        Issue issue = issueRepository.findById(issueId)
+                .orElseThrow(IssueNotFoundException::new)
+                .updateStatus(openStatus);
+
+        issueRepository.updateOpenStatus(issue.getId(), issue.isOpen());
+
+        return issue;
+    }
+
     public void addLabel(Long issueId, String labelId) {
         Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.addLabel(labelId);

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -4,16 +4,16 @@ import com.issuetracker.domain.issue.request.IssueSearchCondition;
 import java.util.HashMap;
 
 import com.issuetracker.domain.issue.response.IssueDetailsResponse;
+
+import com.issuetracker.domain.issue.response.SimpleIssue;
 import com.issuetracker.global.exception.issue.IssueNotFoundException;
 import lombok.RequiredArgsConstructor;
+import com.issuetracker.domain.issue.response.IssueDetailResponse;
 import org.springframework.stereotype.Service;
 import java.util.Map;
-import com.issuetracker.domain.issue.response.IssueListResponse;
-import com.issuetracker.domain.issue.response.IssueResponse;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +28,6 @@ public class IssueService {
         Issue savedIssue = issueRepository.save(issue);
         return savedIssue.getId();
     }
-
 
     @Transactional(readOnly = true)
     public IssueDetailsResponse getDetail(Long issueId) {
@@ -45,15 +44,11 @@ public class IssueService {
     }
 
     @Transactional(readOnly = true)
-    public IssueListResponse getIssues() {
-        List<Issue> issues = issueRepository.findAll();
-        return IssueListResponse.of(
-                issues.stream().map(IssueResponse::of).collect(Collectors.toList())
-        );
+    public List<SimpleIssue> getIssues() {
+        return issueViewMapper.findAll();
     }
 
     public void addLabel(Long issueId, String labelId) {
-        // TODO: 레이블이 존재하는지 확인하는 로직 넣어야 함
         Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.addLabel(labelId);
 

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -43,11 +43,6 @@ public class IssueService {
         issueMapper.update(form);
     }
 
-    @Transactional(readOnly = true)
-    public List<SimpleIssue> getIssues() {
-        return issueViewMapper.findAll();
-    }
-
     public void addLabel(Long issueId, String labelId) {
         Issue issue = issueRepository.findById(issueId).orElseThrow(IssueNotFoundException::new);
         issue.addLabel(labelId);
@@ -83,15 +78,16 @@ public class IssueService {
         return issueRepository.save(issue);
     }
 
-    public List<Issue> getIssueByCondition(IssueSearchCondition condition) {
+    @Transactional(readOnly = true)
+    public List<SimpleIssue> getIssuesByCondition(IssueSearchCondition condition) {
         Map<String, Object> conditionMap = new HashMap<>();
 
         conditionMap.put("author", condition.getAuthor());
         conditionMap.put("isOpen", condition.isOpen());
         conditionMap.put("milestoneId", condition.getMilestoneId());
         conditionMap.put("labelIds", condition.getLabelIds());
-        conditionMap.put("title", condition.getTitle());
+        conditionMap.put("title", condition.getTitle()); // TODO: content 추가
 
-        return issueMapper.findByCondition(conditionMap);
+        return issueViewMapper.findAllByCondition(conditionMap);
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -1,6 +1,8 @@
 package com.issuetracker.domain.issue;
 
 import com.issuetracker.domain.issue.request.IssueSearchCondition;
+
+import java.util.Arrays;
 import java.util.HashMap;
 
 import com.issuetracker.domain.issue.response.IssueDetailsResponse;
@@ -14,6 +16,7 @@ import java.util.Map;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -43,14 +46,13 @@ public class IssueService {
         issueMapper.update(form);
     }
 
-    public Issue updateStatus(Long issueId, boolean openStatus) {
-        Issue issue = issueRepository.findById(issueId)
-                .orElseThrow(IssueNotFoundException::new)
-                .updateStatus(openStatus);
+    public void updateStatus(String issueIdString, boolean openStatus) {
+        List<Long> issueIds = Arrays.stream(issueIdString.split(","))
+                .map(String::trim)
+                .map(Long::parseLong)
+                .toList();
 
-        issueRepository.updateOpenStatus(issue.getId(), issue.isOpen());
-
-        return issue;
+        issueRepository.updateOpenStatus(issueIds, openStatus);
     }
 
     public void addLabel(Long issueId, String labelId) {

--- a/src/main/java/com/issuetracker/domain/issue/IssueService.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueService.java
@@ -100,6 +100,9 @@ public class IssueService {
         conditionMap.put("milestoneId", condition.getMilestoneId());
         conditionMap.put("labelIds", condition.getLabelIds());
         conditionMap.put("keyword", condition.getKeyword());
+        conditionMap.put("assignees", condition.getAssignees());
+        conditionMap.put("noAssignee", condition.isNoAssignee());
+        conditionMap.put("noMilestone", condition.isNoMilestone());
 
         IssueCount issueCount = issueViewMapper.countByCondition(conditionMap);
         List<SimpleIssue> issues = issueViewMapper.findAllByCondition(conditionMap);

--- a/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
@@ -12,8 +12,6 @@ public interface IssueViewMapper {
 
     IssueDetails findById(Long issueId);
 
-    List<SimpleIssue> findAll();
-
     IssueCount countByCondition(Map<String, Object> conditionMap);
 
     List<SimpleIssue> findAllByCondition(Map<String, Object> conditionMap);

--- a/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
@@ -1,5 +1,6 @@
 package com.issuetracker.domain.issue;
 
+import com.issuetracker.domain.issue.response.IssueCount;
 import com.issuetracker.domain.issue.response.SimpleIssue;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -12,6 +13,8 @@ public interface IssueViewMapper {
     IssueDetails findById(Long issueId);
 
     List<SimpleIssue> findAll();
+
+    IssueCount countByCondition(Map<String, Object> conditionMap);
 
     List<SimpleIssue> findAllByCondition(Map<String, Object> conditionMap);
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
@@ -4,6 +4,7 @@ import com.issuetracker.domain.issue.response.SimpleIssue;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
+import java.util.Map;
 
 @Mapper
 public interface IssueViewMapper {
@@ -11,4 +12,6 @@ public interface IssueViewMapper {
     IssueDetails findById(Long issueId);
 
     List<SimpleIssue> findAll();
+
+    List<SimpleIssue> findAllByCondition(Map<String, Object> conditionMap);
 }

--- a/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
+++ b/src/main/java/com/issuetracker/domain/issue/IssueViewMapper.java
@@ -1,9 +1,14 @@
 package com.issuetracker.domain.issue;
 
+import com.issuetracker.domain.issue.response.SimpleIssue;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface IssueViewMapper {
 
     IssueDetails findById(Long issueId);
+
+    List<SimpleIssue> findAll();
 }

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueSearchCondition.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueSearchCondition.java
@@ -1,11 +1,12 @@
 package com.issuetracker.domain.issue.request;
 
-import com.issuetracker.domain.issue.util.IssueQueryParser;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static com.issuetracker.domain.issue.util.IssueQueryParser.*;
 
 @Getter
 @Builder
@@ -16,27 +17,35 @@ public class IssueSearchCondition {
     private String author;
     private List<String> labelIds;
     private String milestoneId;
+
+    @Builder.Default
     private boolean isOpen = true;
     private List<String> assignees;
     private String keyword;
+    private boolean noMilestone;
+    private boolean noAssignee;
 
     public static IssueSearchCondition of(String requestQueryString) {
-        List<String> queryString = IssueQueryParser.parseQueryString(requestQueryString);
+        List<String> queryString = parseQueryString(requestQueryString);
 
-        String keyword = IssueQueryParser.parseKeyword(queryString);
-        String author = IssueQueryParser.parseAuthor(queryString);
-        List<String> labelIds = IssueQueryParser.parseLabels(queryString);
-        String milestone = IssueQueryParser.parseMilestone(queryString);
-        List<String> assignees = IssueQueryParser.parseAssignees(queryString);
-        boolean isOpen = IssueQueryParser.parseOpenStatus(queryString);
+        String keyword = parseKeyword(queryString);
+        String author = parseAuthor(queryString);
+        List<String> labelIds = parseLabels(queryString);
+        String milestone = parseMilestone(queryString);
+        List<String> assignees = parseAssignees(queryString);
+        boolean isOpen = parseOpenStatus(queryString);
+        boolean noMilestone = parseNoXXX(queryString, NO_MILESTONE_PATTERN.getPattern());
+        boolean noAssignee = parseNoXXX(queryString, NO_ASSIGNEE_PATTERN.getPattern());
 
         return IssueSearchCondition.builder()
                 .author(author)
                 .labelIds(labelIds)
-                .milestoneId(milestone)
+                .milestoneId(noMilestone ? null : milestone)
                 .isOpen(isOpen)
-                .assignees(assignees)
+                .assignees(noAssignee ? null : assignees)
                 .keyword(keyword)
+                .noAssignee(noAssignee)
+                .noMilestone(noMilestone)
                 .build();
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/request/IssueSearchCondition.java
+++ b/src/main/java/com/issuetracker/domain/issue/request/IssueSearchCondition.java
@@ -18,12 +18,12 @@ public class IssueSearchCondition {
     private String milestoneId;
     private boolean isOpen = true;
     private List<String> assignees;
-    private String title;
+    private String keyword;
 
     public static IssueSearchCondition of(String requestQueryString) {
         List<String> queryString = IssueQueryParser.parseQueryString(requestQueryString);
 
-        String issueTitle = IssueQueryParser.parseIssueTitle(queryString);
+        String keyword = IssueQueryParser.parseKeyword(queryString);
         String author = IssueQueryParser.parseAuthor(queryString);
         List<String> labelIds = IssueQueryParser.parseLabels(queryString);
         String milestone = IssueQueryParser.parseMilestone(queryString);
@@ -36,7 +36,7 @@ public class IssueSearchCondition {
                 .milestoneId(milestone)
                 .isOpen(isOpen)
                 .assignees(assignees)
-                .title(issueTitle)
+                .keyword(keyword)
                 .build();
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/response/IssueCount.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/IssueCount.java
@@ -1,0 +1,15 @@
+package com.issuetracker.domain.issue.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class IssueCount {
+
+    private int openIssues;
+    private int closedIssues;
+    private int totalIssues;
+}

--- a/src/main/java/com/issuetracker/domain/issue/response/IssueListResponse.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/IssueListResponse.java
@@ -2,19 +2,23 @@ package com.issuetracker.domain.issue.response;
 
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class IssueListResponse {
 
+    private int openIssues;
+    private int closedIssues;
     private List<IssuePreviewResponse> issues;
 
-    public static IssueListResponse from(List<SimpleIssue> simpleIssues) {
-        return new IssueListResponse(
-                simpleIssues.stream()
-                        .map(IssuePreviewResponse::from)
-                        .toList()
-        );
+    public static IssueListResponse from(IssueCount issueCount, List<SimpleIssue> simpleIssues) {
+        return IssueListResponse.builder()
+                .openIssues(issueCount.getOpenIssues())
+                .closedIssues(issueCount.getClosedIssues())
+                .issues(simpleIssues.stream().map(IssuePreviewResponse::from).toList())
+                .build();
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/response/IssueListResponse.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/IssueListResponse.java
@@ -8,9 +8,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public class IssueListResponse {
 
-    private List<IssueResponse> issues;
+    private List<IssuePreviewResponse> issues;
 
-    public static IssueListResponse of(List<IssueResponse> elements) {
-        return new IssueListResponse(elements);
+    public static IssueListResponse from(List<SimpleIssue> simpleIssues) {
+        return new IssueListResponse(
+                simpleIssues.stream()
+                        .map(IssuePreviewResponse::from)
+                        .toList()
+        );
     }
 }

--- a/src/main/java/com/issuetracker/domain/issue/response/IssuePreviewResponse.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/IssuePreviewResponse.java
@@ -1,0 +1,36 @@
+package com.issuetracker.domain.issue.response;
+
+import com.issuetracker.domain.common.LocalDateTimeToStringConverter;
+import com.issuetracker.domain.label.response.LabelResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class IssuePreviewResponse {
+
+    private Long issueId;
+    private String memberId;
+    private String title;
+    private boolean isOpen;
+    private List<LabelResponse> labels;
+    private String milestoneId;
+    private String createdAt;
+
+    public static IssuePreviewResponse from(SimpleIssue simpleIssue) {
+        return IssuePreviewResponse.builder()
+                .issueId(simpleIssue.getIssueId())
+                .memberId(simpleIssue.getMemberId())
+                .title(simpleIssue.getTitle())
+                .isOpen(simpleIssue.isOpen())
+                .labels(simpleIssue.getLabels().stream().map(LabelResponse::of).toList())
+                .milestoneId(simpleIssue.getMilestoneId())
+                .createdAt(LocalDateTimeToStringConverter.convert(simpleIssue.getCreatedAt(), LocalDateTime.now()))
+                .build();
+    }
+}

--- a/src/main/java/com/issuetracker/domain/issue/response/IssueStatusResponse.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/IssueStatusResponse.java
@@ -1,0 +1,16 @@
+package com.issuetracker.domain.issue.response;
+
+import com.issuetracker.domain.issue.Issue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class IssueStatusResponse {
+
+    private boolean isOpen;
+
+    public static IssueStatusResponse from(Issue issue) {
+        return new IssueStatusResponse(issue.isOpen());
+    }
+}

--- a/src/main/java/com/issuetracker/domain/issue/response/SimpleIssue.java
+++ b/src/main/java/com/issuetracker/domain/issue/response/SimpleIssue.java
@@ -1,0 +1,22 @@
+package com.issuetracker.domain.issue.response;
+
+import com.issuetracker.domain.label.Label;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SimpleIssue {
+
+    private Long issueId;
+    private String memberId;
+    private String title;
+    private boolean isOpen;
+    private Set<Label> labels;
+    private String milestoneId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/issuetracker/domain/issue/util/IssueQueryParser.java
+++ b/src/main/java/com/issuetracker/domain/issue/util/IssueQueryParser.java
@@ -6,18 +6,23 @@ import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum IssueQueryParser {
 
-    QUERY_STRING_PATTERN(Pattern.compile("(is:open|is:closed|label:[^\"]\\S+|label:\".*?\"|author:[^\"]\\S+|author:\".*?\"|milestone:[^\"]\\S+|milestone:\".*?\"|\\S+)")),
-    KEYWORD_PATTERN(Pattern.compile("\\b(?!is:open\\b|is:closed\\b|label:.+\\b|milestone:.+\\b|author:.+\\b|assignee:.+\\b)(\\S+)")),
+    QUERY_STRING_PATTERN(Pattern.compile("(no:milestone|no:assignee|is:open|is:closed|label:[^\"]\\S+|label:\".*?\"|author:[^\"]\\S+|author:\".*?\"|milestone:[^\"]\\S+|milestone:\".*?\"|\\S+)")),
+    KEYWORD_PATTERN(Pattern.compile("\\b(?!no:milestone\\b|no:assignee\\b|is:open\\b|is:closed\\b|label:.+\\b|milestone:.+\\b|author:.+\\b|assignee:.+\\b)(\\S+)")),
     AUTHOR_PATTERN(Pattern.compile("(?i)author:\"?([^\"]+)")),
     LABELS_PATTERN(Pattern.compile("(?i)label:\"?([^\"]+)")),
     MILESTONE_PATTERN(Pattern.compile("(?i)milestone:\"?([^\"]+)")),
     ASSIGNEE_PATTERN(Pattern.compile("(?i)assignee:\"?([^\"]+)")),
-    OPEN_STATUS_PATTERN(Pattern.compile("(?i)is:(open|closed)"));
+    OPEN_STATUS_PATTERN(Pattern.compile("(?i)is:(open|closed)")),
+    NO_MILESTONE_PATTERN(Pattern.compile("(?i)no:milestone")),
+    NO_ASSIGNEE_PATTERN(Pattern.compile("(?i)no:assignee"));
 
     private static final int MATCH_INDEX = 1;
     private static final String SPACE = " ";
@@ -76,6 +81,11 @@ public enum IssueQueryParser {
                 })
                 .findAny()
                 .orElse(null);
+    }
+
+    public static boolean parseNoXXX(List<String> queryString, Pattern pattern) {
+        return queryString.stream()
+                .anyMatch(str -> MATCHER_CONVERTER.apply(pattern, str).matches());
     }
 
     public static List<String> parseAssignees(List<String> queryString) {

--- a/src/main/java/com/issuetracker/domain/issue/util/IssueQueryParser.java
+++ b/src/main/java/com/issuetracker/domain/issue/util/IssueQueryParser.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 public enum IssueQueryParser {
 
     QUERY_STRING_PATTERN(Pattern.compile("(is:open|is:closed|label:[^\"]\\S+|label:\".*?\"|author:[^\"]\\S+|author:\".*?\"|milestone:[^\"]\\S+|milestone:\".*?\"|\\S+)")),
-    ISSUE_TITLE_PATTERN(Pattern.compile("\\b(?!is:open\\b|is:closed\\b|label:.+\\b|milestone:.+\\b|author:.+\\b|assignee:.+\\b)(\\S+)")),
+    KEYWORD_PATTERN(Pattern.compile("\\b(?!is:open\\b|is:closed\\b|label:.+\\b|milestone:.+\\b|author:.+\\b|assignee:.+\\b)(\\S+)")),
     AUTHOR_PATTERN(Pattern.compile("(?i)author:\"?([^\"]+)")),
     LABELS_PATTERN(Pattern.compile("(?i)label:\"?([^\"]+)")),
     MILESTONE_PATTERN(Pattern.compile("(?i)milestone:\"?([^\"]+)")),
@@ -36,11 +36,11 @@ public enum IssueQueryParser {
         return queryString;
     }
 
-    public static String parseIssueTitle(List<String> queryString) {
+    public static String parseKeyword(List<String> queryString) {
         return queryString.stream()
-                .filter(str -> MATCHER_CONVERTER.apply(ISSUE_TITLE_PATTERN.pattern, str).matches())
+                .filter(str -> MATCHER_CONVERTER.apply(KEYWORD_PATTERN.pattern, str).matches())
                 .map(str -> {
-                    Matcher matcher = MATCHER_CONVERTER.apply(ISSUE_TITLE_PATTERN.pattern, str);
+                    Matcher matcher = MATCHER_CONVERTER.apply(KEYWORD_PATTERN.pattern, str);
                     return matcher.find() ? matcher.group(MATCH_INDEX) : "";
                 })
                 .collect(Collectors.joining(SPACE));

--- a/src/main/resources/mapper/issue/Issue.xml
+++ b/src/main/resources/mapper/issue/Issue.xml
@@ -16,42 +16,4 @@
         WHERE ISSUE_ID = #{issueId}
     </update>
 
-    <resultMap id="IssueResultMap" type="com.issuetracker.domain.issue.Issue">
-        <id property="id" column="ISSUE_ID" />
-        <result property="memberId" column="MEMBER_ID" />
-        <result property="isOpen" column="IS_OPEN" />
-        <result property="title" column="TITLE" />
-        <result property="milestoneRef" column="MILESTONE_ID" typeHandler="com.issuetracker.domain.issue.AggregateReferenceTypeHandler"/>
-        <collection property="issueLabels" column="ISSUE_ID" javaType="java.util.Set" ofType="com.issuetracker.domain.issue.IssueLabel"
-                    select="com.issuetracker.domain.issue.IssueLabelMapper.findByIssueId"/>
-    </resultMap>
-
-    <select id="findByCondition" parameterType="Map" resultMap="IssueResultMap">
-        SELECT I.* FROM ISSUE I
-        <where>
-            <if test="author != null and author != ''">
-                I.MEMBER_ID = #{author}
-            </if>
-            <if test="milestoneId != null and milestoneId != ''">
-                AND I.MILESTONE_ID = #{milestoneId}
-            </if>
-            <if test="labelIds != null and labelIds.size() > 0">
-                AND EXISTS (
-                    SELECT 1 FROM ISSUE_LABEL IL
-                    WHERE IL.ISSUE_ID = I.ISSUE_ID
-                    AND IL.LABEL_ID IN
-                    <foreach item="labelId" index="index" collection="labelIds" open="(" separator="," close=")">
-                        #{labelId}
-                    </foreach>
-                    )
-            </if>
-            <if test="title != null and title != ''">
-                AND I.TITLE LIKE CONCAT('%', #{title}, '%')
-            </if>
-            <if test="isOpen != null">
-                AND I.IS_OPEN = #{isOpen}
-            </if>
-        </where>
-    </select>
-
 </mapper>

--- a/src/main/resources/mapper/issue/SimpleIssue.xml
+++ b/src/main/resources/mapper/issue/SimpleIssue.xml
@@ -10,14 +10,6 @@
         <result property="totalIssues" column="TOTAL_ISSUES" />
     </resultMap>
 
-    <!-- LabelResultMap -->
-    <resultMap id="LabelResultMap" type="com.issuetracker.domain.label.Label">
-        <id property="id" column="LABEL_ID" />
-        <result property="description" column="DESCRIPTION" />
-        <result property="textColor" column="TEXT_COLOR" />
-        <result property="colorCode" column="COLOR_CODE" />
-    </resultMap>
-
     <!-- SimpleIssueResultMap -->
     <resultMap id="SimpleIssueResultMap" type="com.issuetracker.domain.issue.response.SimpleIssue">
         <id property="issueId" column="ISSUE_ID" />

--- a/src/main/resources/mapper/issue/SimpleIssue.xml
+++ b/src/main/resources/mapper/issue/SimpleIssue.xml
@@ -50,6 +50,9 @@
                     #{labelId}
                 </foreach>
             </if>
+            <if test="noMilestone == true">
+                AND I.MILESTONE_ID IS NULL
+            </if>
             <if test="keyword != null and keyword != ''">
                 AND (I.TITLE LIKE CONCAT('%', #{keyword}, '%') OR I.CONTENT LIKE CONCAT('%', #{keyword}, '%'))
             </if>
@@ -85,6 +88,9 @@
                 <foreach item="labelId" index="index" collection="labelIds" open="(" separator="," close=")">
                     #{labelId}
                 </foreach>
+            </if>
+            <if test="noMilestone == true">
+                AND I.MILESTONE_ID IS NULL
             </if>
             <if test="keyword != null and keyword != ''">
                 AND ((I.TITLE LIKE CONCAT('%', #{keyword}, '%')) OR (I.CONTENT LIKE CONCAT('%', #{keyword}, '%')))

--- a/src/main/resources/mapper/issue/SimpleIssue.xml
+++ b/src/main/resources/mapper/issue/SimpleIssue.xml
@@ -3,6 +3,13 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.issuetracker.domain.issue.IssueViewMapper">
 
+    <!-- IssueCountResultMap -->
+    <resultMap id="IssueCountResultMap" type="com.issuetracker.domain.issue.response.IssueCount">
+        <result property="openIssues" column="OPEN_ISSUES" />
+        <result property="closedIssues" column="CLOSED_ISSUES" />
+        <result property="totalIssues" column="TOTAL_ISSUES" />
+    </resultMap>
+
     <!-- LabelResultMap -->
     <resultMap id="LabelResultMap" type="com.issuetracker.domain.label.Label">
         <id property="id" column="LABEL_ID" />
@@ -21,6 +28,33 @@
         <result property="createdAt" column="ISSUE_CREATED_AT" />
         <collection property="labels" ofType="com.issuetracker.domain.label.Label" resultMap="LabelResultMap" javaType="java.util.Set" />
     </resultMap>
+
+    <select id="countByCondition" resultMap="IssueCountResultMap">
+        SELECT
+            COUNT(CASE WHEN I.IS_OPEN = TRUE THEN 1 END) AS OPEN_ISSUES,
+            COUNT(CASE WHEN I.IS_OPEN = FALSE THEN 1 END) AS CLOSED_ISSUES,
+            COUNT(*) AS TOTAL_ISSUES
+        FROM ISSUE I
+        LEFT JOIN ISSUE_LABEL IL ON I.ISSUE_ID = IL.ISSUE_ID
+        LEFT JOIN LABEL L ON IL.LABEL_ID = L.LABEL_ID
+        <where>
+            <if test="author != null and author != ''">
+                AND I.MEMBER_ID = #{author}
+            </if>
+            <if test="milestoneId != null and milestoneId != ''">
+                AND I.MILESTONE_ID = #{milestoneId}
+            </if>
+            <if test="labelIds != null and labelIds.size() > 0">
+                AND IL.LABEL_ID IN
+                <foreach item="labelId" index="index" collection="labelIds" open="(" separator="," close=")">
+                    #{labelId}
+                </foreach>
+            </if>
+            <if test="keyword != null and keyword != ''">
+                AND (I.TITLE LIKE CONCAT('%', #{keyword}, '%') OR I.CONTENT LIKE CONCAT('%', #{keyword}, '%'))
+            </if>
+        </where>
+    </select>
 
     <select id="findAllByCondition" resultMap="SimpleIssueResultMap">
         SELECT

--- a/src/main/resources/mapper/issue/simpleIssue.xml
+++ b/src/main/resources/mapper/issue/simpleIssue.xml
@@ -44,7 +44,7 @@
                 I.MEMBER_ID = #{author}
             </if>
             <if test="milestoneId != null and milestoneId != ''">
-                AND I.MILESTOND_ID = #{milestoneId}
+                AND I.MILESTONE_ID = #{milestoneId}
             </if>
             <if test="labelIds != null and labelIds.size() > 0">
                 AND IL.LABEL_ID IN
@@ -52,8 +52,8 @@
                     #{labelId}
                 </foreach>
             </if>
-            <if test="title != null and title != ''">
-                AND I.TITLE LIKE CONCAT('%', #{title}, '%')
+            <if test="keyword != null and keyword != ''">
+                AND ((I.TITLE LIKE CONCAT('%', #{keyword}, '%')) OR (I.CONTENT LIKE CONCAT('%', #{keyword}, '%')))
             </if>
             <if test="isOpen != null">
                 AND I.IS_OPEN = #{isOpen}

--- a/src/main/resources/mapper/issue/simpleIssue.xml
+++ b/src/main/resources/mapper/issue/simpleIssue.xml
@@ -22,7 +22,7 @@
         <collection property="labels" ofType="com.issuetracker.domain.label.Label" resultMap="LabelResultMap" javaType="java.util.Set" />
     </resultMap>
 
-    <select id="findAll" resultMap="SimpleIssueResultMap">
+    <select id="findAllByCondition" resultMap="SimpleIssueResultMap">
         SELECT
             I.ISSUE_ID,
             I.MEMBER_ID AS ISSUE_MEMBER_ID,
@@ -39,6 +39,26 @@
              ISSUE_LABEL IL ON I.ISSUE_ID = IL.ISSUE_ID
                  LEFT JOIN
              LABEL L ON IL.LABEL_ID = L.LABEL_ID
+        <where>
+            <if test="author != null and author != ''">
+                I.MEMBER_ID = #{author}
+            </if>
+            <if test="milestoneId != null and milestoneId != ''">
+                AND I.MILESTOND_ID = #{milestoneId}
+            </if>
+            <if test="labelIds != null and labelIds.size() > 0">
+                AND IL.LABEL_ID IN
+                <foreach item="labelId" index="index" collection="labelIds" open="(" separator="," close=")">
+                    #{labelId}
+                </foreach>
+            </if>
+            <if test="title != null and title != ''">
+                AND I.TITLE LIKE CONCAT('%', #{title}, '%')
+            </if>
+            <if test="isOpen != null">
+                AND I.IS_OPEN = #{isOpen}
+            </if>
+        </where>
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/issue/simpleIssue.xml
+++ b/src/main/resources/mapper/issue/simpleIssue.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.issuetracker.domain.issue.IssueViewMapper">
+
+    <!-- LabelResultMap -->
+    <resultMap id="LabelResultMap" type="com.issuetracker.domain.label.Label">
+        <id property="id" column="LABEL_ID" />
+        <result property="description" column="DESCRIPTION" />
+        <result property="textColor" column="TEXT_COLOR" />
+        <result property="colorCode" column="COLOR_CODE" />
+    </resultMap>
+
+    <!-- SimpleIssueResultMap -->
+    <resultMap id="SimpleIssueResultMap" type="com.issuetracker.domain.issue.response.SimpleIssue">
+        <id property="issueId" column="ISSUE_ID" />
+        <result property="memberId" column="ISSUE_MEMBER_ID" />
+        <result property="title" column="TITLE" />
+        <result property="isOpen" column="IS_OPEN" />
+        <result property="milestoneId" column="MILESTONE_ID" />
+        <result property="createdAt" column="ISSUE_CREATED_AT" />
+        <collection property="labels" ofType="com.issuetracker.domain.label.Label" resultMap="LabelResultMap" javaType="java.util.Set" />
+    </resultMap>
+
+    <select id="findAll" resultMap="SimpleIssueResultMap">
+        SELECT
+            I.ISSUE_ID,
+            I.MEMBER_ID AS ISSUE_MEMBER_ID,
+            I.TITLE,
+            I.IS_OPEN,
+            I.MILESTONE_ID,
+            I.CREATED_AT AS ISSUE_CREATED_AT,
+            L.LABEL_ID,
+            L.DESCRIPTION,
+            L.TEXT_COLOR,
+            L.COLOR_CODE
+        FROM ISSUE I
+                 LEFT JOIN
+             ISSUE_LABEL IL ON I.ISSUE_ID = IL.ISSUE_ID
+                 LEFT JOIN
+             LABEL L ON IL.LABEL_ID = L.LABEL_ID
+    </select>
+
+</mapper>

--- a/src/test/java/com/issuetracker/domain/issue/IssueTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.issuetracker.domain.comment.Comment;
 import com.issuetracker.domain.issue.request.IssueSearchCondition;
+import com.issuetracker.domain.issue.response.SimpleIssue;
 import com.issuetracker.domain.label.Label;
 import com.issuetracker.domain.label.LabelRepository;
 import com.issuetracker.domain.member.Member;
@@ -33,7 +34,7 @@ class IssueTest {
     private IssueRepository issueRepository;
 
     @Autowired
-    private IssueMapper issueMapper;
+    private IssueViewMapper issueViewMapper;
 
     @Autowired
     private LabelRepository labelRepository;
@@ -292,10 +293,10 @@ class IssueTest {
         conditionMap.put("isOpen", condition.isOpen());
         conditionMap.put("milestoneId", condition.getMilestoneId());
         conditionMap.put("labelIds", condition.getLabelIds());
-        conditionMap.put("title", condition.getTitle());
+        conditionMap.put("keyWord", condition.getKeyword());
 
         // when
-        List<Issue> issues = issueMapper.findByCondition(conditionMap);
+        List<SimpleIssue> issues = issueViewMapper.findAllByCondition(conditionMap);
 
         // then
         assertThat(issues).hasSize(1);

--- a/src/test/java/com/issuetracker/domain/issue/IssueTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/IssueTest.java
@@ -48,7 +48,7 @@ class IssueTest {
     void setUp() {
         Member member = Member.builder()
                 .id("tester")
-                .password("123")
+                .encodedPassword("123")
                 .build();
 
         testMember = memberRepository.save(member);

--- a/src/test/java/com/issuetracker/domain/issue/argumentresolver/IssueQueryParserTest.java
+++ b/src/test/java/com/issuetracker/domain/issue/argumentresolver/IssueQueryParserTest.java
@@ -30,7 +30,7 @@ class IssueQueryParserTest {
         List<String> parsedQueryString = IssueQueryParser.parseQueryString(QUERY_STRING);
 
         // when
-        String issueTitle = IssueQueryParser.parseIssueTitle(parsedQueryString);
+        String issueTitle = IssueQueryParser.parseKeyword(parsedQueryString);
 
         // then
         assertThat(issueTitle).isEqualTo("검색 기능");

--- a/src/test/java/com/issuetracker/domain/member/MemberTest.java
+++ b/src/test/java/com/issuetracker/domain/member/MemberTest.java
@@ -19,7 +19,7 @@ class MemberTest {
         // given
         Member member = Member.builder()
                 .id("tester")
-                .password("1234")
+                .encodedPassword("1234")
                 .build();
 
         // when


### PR DESCRIPTION
# 🚀 Pull Request

## 구현 내용
- 이슈 아이디 목록을 입력받아 (ex - 1,2,3) 한 번에 상태를 변경하는 기능을 구현했습니다.
- 이슈 목록 조회 시 필요한 데이터를 한 번에 받아오도록 구현했습니다. 열린 이슈 개수, 닫힌 이슈 개수도 함께 조회합니다.
- 이슈 필터링 조건을 추가했습니다. no:milestone, no:assignee 

## 기타
- no:assignee나 assignee에 대한 이슈 필터링은 이루어지지 않고 있습니다. 이 부분은 멤버 관련 기능 구현 시 적용할 예정입니다.

## 관련 이슈
close #44 
