### PR TITLE
[Feat/#71] 마일스톤 화면 작업

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -252,7 +252,7 @@
   }
 
   .issue-filter.open {
-    @apply pl-[2rem]
+    @apply pl-[1rem]
   }
 
   .issue-filter.closed {
@@ -329,7 +329,7 @@
   }
 
   .label-description {
-    @apply mx-4 my-1 min-w-[250px] text-gray-800 truncate
+    @apply mx-4 my-1 text-[14px] min-w-[250px] text-gray-500 truncate
   }
 
   .label-btn-container {

--- a/frontend/src/components/common/LabelMilestoneNavtab.svelte
+++ b/frontend/src/components/common/LabelMilestoneNavtab.svelte
@@ -1,13 +1,26 @@
 <script>
     import { router } from "tinro";
     import { onMount } from 'svelte';
+    import { labels } from '../../stores/label'
+    import { milestones } from '../../stores/milestone'
 
     let isLabelDisabled = false;
     let isMilestoneDisabled = false;
+    let milestoneCounts = 0
 
-    onMount(() => {
+    $: labelCounts = $labels.labels.length
+    $: milestoneCounts = $milestones.milestones.length
+
+    onMount(async () => {
         isLabelDisabled = window.location.pathname === '/labels';
+        if (!isLabelDisabled) {
+            await labels.fetchLabels();
+        }
+
         isMilestoneDisabled = window.location.pathname === '/milestones';
+        if (!isMilestoneDisabled) {
+            await milestones.fetchMilestones();
+        }
     });
 </script>
 
@@ -17,13 +30,13 @@
     <span class="text-[16px]">
         <i class="bi bi-tag"></i>
     </span>
-        레이블(3)
+        레이블({labelCounts})
     </button>
     <button type="button" class="gray-btn label-milestone-panel rounded-e-2xl"
             on:click={() => router.goto("/milestones")} disabled={isMilestoneDisabled}>
     <span class="text-[16px]">
         <i class="bi bi-signpost"></i>
     </span>
-        마일스톤(1)
+        마일스톤({milestoneCounts})
     </button>
 </div>

--- a/frontend/src/components/issue/IssueItem.svelte
+++ b/frontend/src/components/issue/IssueItem.svelte
@@ -16,7 +16,7 @@
             </span>
                 <a href="/issues/{issue.issueId}">{issue.title}</a>
                 <!-- 레이블 뱃지 -->
-                {#each issue.labelNames as label}
+                {#each issue.labels as label}
                     <div class="label-badge-container">
                         <div class="label-badge border border-gray-200"
                             style="background-color: {label.colorCode}; color: {label.textColor};">
@@ -36,12 +36,12 @@
                 이 이슈가 {issue.createdAt}, {issue.memberId}님에 의해 작성되었습니다.
             </div>
             <!-- 마일스톤 -->
-            {#if issue.milestoneName !== null}
+            {#if issue.milestoneId !== null}
                 <div>
                     <span class="text-[16px]">
                         <i class="bi bi-signpost"></i>
                     </span>
-                    {issue.milestoneName}
+                    {issue.milestoneId}
                 </div>
             {:else}
             <div class="text-sm">

--- a/frontend/src/components/issue/IssueList.svelte
+++ b/frontend/src/components/issue/IssueList.svelte
@@ -45,7 +45,7 @@
         <!--    카테고리: 레이블/마일스톤 이동버튼 패널   -->
         <div class="flex justify-between items-center">
             <LabelMilestoneNavTab />
-            <button type="button" class="btn issue create max-h-[44px] h-lvh" on:click={() => router.goto("/issues/add")}>
+            <button type="button" class="btn issue create min-w-[165px] max-h-[44px] h-lvh" on:click={() => router.goto("/issues/add")}>
                 <span>
                     <i class="bi bi-plus-lg"></i>
                 </span>

--- a/frontend/src/components/label/LabelEditForm.svelte
+++ b/frontend/src/components/label/LabelEditForm.svelte
@@ -90,9 +90,9 @@
         <div class="label-form-input-container">
             <div class="flex flex-col gap-3" role="group">
                 <div class="label-form-input-box">
-                        <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
-                            이름
-                        </span>
+                    <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
+                        이름
+                    </span>
                     <input id="labelId" class="px-[6rem]" type="text" bind:value={label.labelId}
                            placeholder="레이블의 이름을 입력하세요" maxlength="20"/>
                 </div>

--- a/frontend/src/components/label/LabelList.svelte
+++ b/frontend/src/components/label/LabelList.svelte
@@ -7,7 +7,7 @@
 
 <div class="flex flex-col w-full min-w-[1020px] items-center">
     <div class="issue-table-header">
-        <div class="text-sm text-gray-600">
+        <div class="ml-4 text-sm text-gray-600">
             <span>{$labels.labels.length}개의 레이블</span>
         </div>
     </div>

--- a/frontend/src/components/label/LabelPreview.svelte
+++ b/frontend/src/components/label/LabelPreview.svelte
@@ -38,7 +38,7 @@
             </div>
 
             <!--      레이블 편집 버튼      -->
-            <div class="label-btn-container ml-auto flex gap-2 mx-4 my-1 items-center text-sm whitespace-nowrap">
+            <div class="label-btn-container ml-auto flex gap-4 mx-4 my-1 items-center text-sm whitespace-nowrap">
                 <button class="text-gray-800" on:click={() => onEditModeLabel(label.labelId)}>
                     <span>
                         <i class="bi bi-pencil-square"></i>

--- a/frontend/src/components/milestone/MilestoneAddForm.svelte
+++ b/frontend/src/components/milestone/MilestoneAddForm.svelte
@@ -1,6 +1,6 @@
 <script>
-    import {milestones} from '../../stores/milestone.js'
-    import {milestoneValidate} from "../../utils/validates.js";
+    import { milestones } from '../../stores/milestone.js'
+    import { milestoneValidate } from "../../utils/validates.js";
     import { DateInput } from 'date-picker-svelte'
 
     let milestone = {
@@ -8,6 +8,9 @@
         dueDate: null,
         description: null,
     }
+
+    //TODO: 레이블과 마일스톤 모두 $: 반응형으로 바라보고 있는 데이터와 Input 태그 바인딩 연결을 끊어야함
+    $: isSubmitLocked = milestone.id === null ? true : milestone.id.trim() === ''
 
     const onAddMilestone = async () => {
         try {
@@ -23,32 +26,60 @@
         milestone.id = ''
         milestone.dueDate = null
         milestone.description = ''
+        milestones.toggleAddModeMilestone()
     }
 
 </script>
 
-<div>
-    <div>
-        <div>
-            <label for="milestoneId">이름</label>
-            <input id="milestoneId" type="text" bind:value={milestone.id} placeholder="마일스톤의 이름을 입력하세요" maxlength="30" />
-        </div>
-        <div>
-            <label>완료일(선택)</label>
-            <DateInput bind:value={milestone.dueDate} format="yyyy.MM.dd" placeholder="YYYY.MM.DD"/>
-        </div>
-        <div>
-            <label for="description">설명(선택)</label>
-            <input id="description" type="text" bind:value={milestone.description} placeholder="마일스톤에 대한 설명을 입력하세요" maxlength="50" />
-        </div>
-    </div>
+<div class="label-form-container animate-slidein">
+    <div class="flex flex-col gap-2 justify-between">
+        <div class="label-form-header">새로운 마일스톤 추가</div>
+        <div class="flex items-center">
+            <div class="label-form-input-container">
+                <div class="flex flex-col gap-3" role="group">
+                    <div class="flex gap-3 justify-between items-center">
 
-    <div>
-        <button on:click={onCancelAddMilestone}>취소</button>
-        <button on:click={onAddMilestone}>완료</button>
+                        <div class="label-form-input-box">
+                            <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
+                                이름
+                            </span>
+                            <input id="labelId" class="px-[6rem]" type="text" bind:value={milestone.id}
+                                   placeholder="마일스톤의 이름을 입력하세요" maxlength="30"/>
+                        </div>
+
+                        <div class="label-form-input-box">
+                            <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
+                                완료일(선택)
+                            </span>
+                            <input id="labelId" class="px-[6rem]" type="text" bind:value={milestone.dueDate} placeholder="YYYY.MM.DD" maxlength="30" />
+                            <DateInput class="w-full border-none" bind:value={milestone.dueDate} format="yyyy.MM.dd" placeholder="YYYY.MM.DD"/>
+                        </div>
+                    </div>
+
+                    <div class="label-form-input-box">
+                        <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
+                            설명(선택)
+                        </span>
+                        <input id="description" class="px-[6rem]" type="text" bind:value={milestone.description}
+                               placeholder="마일스톤에 대한 설명을 입력하세요" maxlength="50"/>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+        <div class="edit-title-container gap-3">
+            <button class="edit-title-btn blue-border gap-2" on:click={onCancelAddMilestone}>
+                <span>
+                    <i class="bi bi-x-lg"></i>
+                </span>
+                취소
+            </button>
+            <button class="edit-title-btn apply gap-2" on:click={onAddMilestone} disabled={isSubmitLocked}>
+                <span class="text-white">
+                    <i class="bi bi-plus-lg"></i>
+                </span>
+                완료
+            </button>
+        </div>
     </div>
 </div>
-
-<style>
-
-</style>

--- a/frontend/src/components/milestone/MilestoneEditForm.svelte
+++ b/frontend/src/components/milestone/MilestoneEditForm.svelte
@@ -1,26 +1,31 @@
 <script>
-    import {milestones} from "../../stores/milestone.js";
-    import {DateInput} from "date-picker-svelte";
+    import { milestones } from "../../stores/milestone.js";
+    import { DateInput } from "date-picker-svelte";
 
     export let milestone;
-    let originData = {...milestone}
+
+    // 원본으로부터 생성
+    let updateData = {...milestone}
+
+    let isSubmitLocked = true;
+    $: isSubmitLocked = updateData.id === null ? true : updateData.id.trim() === ''
 
     const parseDate = (str) => {
         return str ? new Date(str) : null;
     }
 
-    $: milestone.dueDate = parseDate(milestone.dueDate)
+    $: updateData.dueDate = parseDate(updateData.dueDate)
 
     const onCloseEditModeMilestone = () => {
-        milestone = {...originData}
+        updateData = {...milestone} // 원본으로부터 원복
         milestones.closeEditModeMilestone()
     }
 
     const onUpdateMilestone = () => {
-        const changes = diff(originData, milestone);
+        const changes = diff(milestone, updateData);
         if(Object.keys(changes).length > 0) {
             if(changes.id !== null && changes.id !== '') {
-                milestones.updateMilestone(originData.id, changes);
+                milestones.updateMilestone(milestone.id, changes);
             }
         }
     }
@@ -36,24 +41,48 @@
     }
 </script>
 
-<div class="milestone-form-container">
-    <div>
-        <div>
-            <label for="milestoneId">이름</label>
-            <input id="milestoneId" type="text" bind:value={milestone.id} placeholder="마일스톤의 이름을 입력하세요" maxlength="30" />
-        </div>
-        <div>
-            <label for="dueDate">완료일(선택)</label>
-            <DateInput bind:value={milestone.dueDate} format="yyyy.MM.dd" placeholder="YYYY.MM.DD"/>
-        </div>
-        <div>
-            <label for="description">설명(선택)</label>
-            <input id="description" type="text" bind:value={milestone.description} placeholder="마일스톤에 대한 설명을 입력하세요" maxlength="50" />
+<div class="label-form-edit-container animate-slidein">
+    <div class="label-form-header">마일스톤 편집</div>
+    <div class="flex items-center">
+        <div class="label-form-input-container">
+            <div class="label-form-input-box">
+                <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
+                    이름
+                </span>
+                <input id="labelId" class="px-[6rem]" type="text" bind:value={updateData.id}
+                       placeholder="마일스톤의 이름을 입력하세요" maxlength="30"/>
+            </div>
+
+            <div class="label-form-input-box">
+                <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
+                    완료일(선택)
+                </span>
+                <input id="labelId" class="px-[6rem]" type="text" bind:value={updateData.dueDate} placeholder="YYYY.MM.DD" maxlength="30" />
+                <DateInput class="w-full border-none" bind:value={updateData.dueDate} format="yyyy.MM.dd" placeholder="YYYY.MM.DD"/>
+            </div>
+
+            <div class="label-form-input-box">
+                <span class="absolute translate-y-2 ml-1 text-[14px] text-gray-500 left-[10px] top-[6px] pointer-events-none">
+                    설명(선택)
+                </span>
+                <input id="description" class="px-[6rem]" type="text" bind:value={updateData.description}
+                       placeholder="마일스톤에 대한 설명을 입력하세요" maxlength="50"/>
+            </div>
         </div>
     </div>
 
-    <div>
-        <button on:click={onCloseEditModeMilestone}>취소</button>
-        <button on:click={onUpdateMilestone}>완료</button>
+    <div class="edit-title-container gap-3">
+        <button class="edit-title-btn blue-border gap-2" on:click={onCloseEditModeMilestone}>
+            <span class="">
+                <i class="bi bi-x-lg"></i>
+            </span>
+            취소
+        </button>
+        <button class="edit-title-btn apply gap-2" on:click={onUpdateMilestone} disabled={isSubmitLocked}>
+            <span class="text-white">
+                <i class="bi bi-plus-lg"></i>
+            </span>
+            완료
+        </button>
     </div>
 </div>

--- a/frontend/src/components/milestone/MilestoneList.svelte
+++ b/frontend/src/components/milestone/MilestoneList.svelte
@@ -1,33 +1,50 @@
 <script>
     import {milestones} from "../../stores/milestone.js";
     import MilestonePreview from "./MilestonePreview.svelte";
+    import NoMilestone from "./NoMilestone.svelte";
+
+    $: openMilestones = $milestones.milestones.filter(milestone => milestone.open === true)
+    $: closedMilestones = $milestones.milestones.filter(milestone => milestone.open === false)
+
+    $: isOpenMilestoneView = true
+
+    const onOpenMilestonesView = () => {
+        isOpenMilestoneView = true
+    }
+
+    const onClosedMilestonesView = () => {
+        isOpenMilestoneView = false
+    }
 </script>
 
-<div class="milestone-list-box">
-    <div class="milestone-list">
-        <h3>{$milestones.milestones.length}개의 마일스톤</h3>
+<div class="flex flex-col w-full min-w-[1020px] items-center">
+    <div class="issue-table-header">
+        <button class="issue-filter open" on:click={onOpenMilestonesView}>
+            <span class="pr-[3px]">
+                <i class="bi bi-exclamation-circle"></i>
+            </span>
+            <span class={isOpenMilestoneView ? 'font-bold text-black' : ''}>열린 마일스톤({openMilestones.length})</span>
+        </button>
+        <button class="issue-filter closed" on:click={onClosedMilestonesView}>
+            <span class="pr-[3px]">
+                <i class="bi bi-archive"></i>
+            </span>
+            <span class={!isOpenMilestoneView ? 'font-bold text-black' : ''}>닫힌 마일스톤({closedMilestones.length})</span>
+        </button>
     </div>
-    <div class="label-element">
-        {#each $milestones.milestones as milestone}
+    {#if isOpenMilestoneView}
+        {#each openMilestones as milestone}
             <MilestonePreview {milestone} />
         {/each}
-    </div>
+        {#if openMilestones.length === 0}
+            <NoMilestone isOpen={true} />
+        {/if}
+    {:else}
+        {#each closedMilestones as milestone}
+            <MilestonePreview {milestone} />
+        {/each}
+        {#if closedMilestones.length === 0}
+            <NoMilestone isOpen={false} />
+        {/if}
+    {/if}
 </div>
-
-<style>
-    h3 {
-        font-size: 14px;
-        line-height: 24px;
-        margin: 0px;
-    }
-    .milestone-list-box {
-        border: 1px solid #d9dbe9;
-        border-radius: 16px;
-    }
-    .milestone-list {
-        border-color: transparent;
-        border-radius: 16px 16px 0 0;
-        padding: 16px;
-        background: #f7f7fc;
-    }
-</style>

--- a/frontend/src/components/milestone/MilestonePreview.svelte
+++ b/frontend/src/components/milestone/MilestonePreview.svelte
@@ -1,5 +1,5 @@
 <script>
-    import {milestones} from "../../stores/milestone.js";
+    import { milestones } from "../../stores/milestone.js";
     import MilestoneEditForm from "./MilestoneEditForm.svelte";
 
     export let milestone;
@@ -12,7 +12,14 @@
         return `${year}-${month}-${day}`;
     }
 
-    $: milestone.dueDate = milestone.dueDate ? formatDateStr(milestone.dueDate) : milestone.dueDate;
+    $: formatDueDate = milestone.dueDate ? formatDateStr(milestone.dueDate) : milestone.dueDate;
+
+    const onCloseMilestone = (id) => {
+        if(confirm('이 마일스톤을 닫겠습니까?')) {
+            const isOpen = false
+            milestones.patchMilestone(id, isOpen)
+        }
+    }
 
     const onEditModeMilestone = (id) => {
         milestones.openEditModeMilestone(id)
@@ -25,56 +32,77 @@
     }
 </script>
 
-<div class="milestone-item">
+<div class="issue-table-row">
     {#if $milestones.editMode === milestone.id}
         <MilestoneEditForm {milestone} />
     {:else}
-        <div>{milestone.id}</div>
-        <div>
-            {#if milestone.dueDate}
-                <p>{milestone.dueDate}</p>
-            {:else}
-                <p>No due date<p>
-            {/if}
-        </div>
-        <div>
-            {#if milestone.description}
-                <div class="milestone-description">
-                    {milestone.description}
+        <div class="flex flex-col items-start">
+            <div class="flex justify-start items-center min-w-[170px]">
+                <div class="flex items-center mx-4 text-[14px] font-bold text-gray-800">
+                <span class="text-[16px] mr-1">
+                    <i class="bi bi-signpost"></i>
+                </span>
+                    {milestone.id}
                 </div>
-            {/if}
+                <div>
+                    <div class="flex gap-2 items-center text-[12px] text-gray-500">
+                        {#if formatDueDate}
+                        <span>
+                            <i class="bi bi-calendar2"></i>
+                        </span>
+                            {formatDueDate}
+                        {:else}
+                        <span>
+                            <i class="bi bi-calendar2"></i>
+                        </span>
+                            지정된 완료일이 없습니다.
+                        {/if}
+                    </div>
+                </div>
+            </div>
+            <div class="ml-4 mt-2 text-[14px] text-gray-500">
+                {#if milestone.description}
+                    {milestone.description}
+                {:else}
+                    마일스톤에 대한 설명이 없습니다.
+                {/if}
+            </div>
         </div>
-        <div class="label-actions">
-            <button class="edit-btn" on:click={() => onEditModeMilestone(milestone.id)}>편집</button>
-            <button class="delete-btn" on:click={() => onDeleteMilestone(milestone.id)}>삭제</button>
+
+        <div class="flex flex-col gap-2 ml-auto justify-between items-center">
+            <!--      편집 버튼      -->
+            <div class="label-btn-container ml-auto flex gap-5 mx-4 my-1 items-center text-sm whitespace-nowrap">
+                <button class="text-gray-800" on:click={() => onCloseMilestone(milestone.id)}>
+                    <span>
+                        <i class="bi bi-archive"></i>
+                    </span>
+                    닫기
+                </button>
+                <button class="text-gray-800" on:click={() => onEditModeMilestone(milestone.id)}>
+                    <span>
+                        <i class="bi bi-pencil-square"></i>
+                    </span>
+                    편집
+                </button>
+                <button class="text-red-500" on:click={() => onDeleteMilestone(milestone.id)}>
+                    <span>
+                        <i class="bi bi-trash"></i>
+                    </span>
+                    삭제
+                </button>
+            </div>
+            <div class="flex flex-col text-[12px]">
+                <div class="flex w-[220px] h-2 bg-gray-300/80 rounded-full overflow-hidden " role="progressbar" aria-valuenow={milestone.progress} aria-valuemin="0" aria-valuemax="100">
+                    <div class="flex flex-col justify-center rounded-full overflow-hidden bg-gray-800/70 text-xs text-white text-center whitespace-nowrap transition duration-500" style="width: {milestone.progress}%"></div>
+                </div>
+                <div class="flex mt-2 justify-between items-center text-gray-600/90">
+                    <span>{milestone.progress}%</span>
+                    <div class="flex gap-1">
+                        <span>열린 이슈 {milestone.openIssues}</span>
+                        <span>닫힌 이슈 {milestone.closeIssues}</span>
+                    </div>
+                </div>
+            </div>
         </div>
     {/if}
 </div>
-
-<style>
-    .milestone-item {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 16px;
-        border-top: 1px solid #d9dbe9;
-        background-color: #fefefe;
-    }
-    .milestone-description {
-        flex: 1;
-        padding-left: 10px;
-        font-size: 14px;
-    }
-    .edit-btn,
-    .delete-btn {
-        background: none;
-        border: none;
-        cursor: pointer;
-    }
-    .edit-btn {
-        color: #007bff;
-    }
-    .delete-btn {
-        color: #dc3545;
-    }
-</style>

--- a/frontend/src/components/milestone/NoMilestone.svelte
+++ b/frontend/src/components/milestone/NoMilestone.svelte
@@ -1,0 +1,15 @@
+<script>
+    export let isOpen
+</script>
+
+<div class="issue-table-row">
+    <div class="issue-content-container justify-center items-center w-full">
+        <div class="flex justify-center my-2 items-center w-full">
+            {#if isOpen}
+            <span class="text-center text-sm text-neutral-600/60 whitespace-nowrap">열려있는 마일스톤이 없습니다.</span>
+            {:else}
+            <span class="text-center text-sm text-neutral-600/60 whitespace-nowrap">닫힌 마일스톤이 없습니다.</span>
+            {/if}
+        </div>
+    </div>
+</div>

--- a/frontend/src/pages/milestone/MilestonePage.svelte
+++ b/frontend/src/pages/milestone/MilestonePage.svelte
@@ -3,6 +3,7 @@
     import MilestoneAddForm from "../../components/milestone/MilestoneAddForm.svelte";
     import MilestoneList from "../../components/milestone/MilestoneList.svelte";
     import { onMount } from "svelte";
+    import LabelMilestoneNavTab from "../../components/common/LabelMilestoneNavtab.svelte";
 
     onMount(() => {
         milestones.fetchMilestones();
@@ -13,40 +14,20 @@
     }
 </script>
 
-<div class="milestone-page">
-    <h1>마일스톤</h1>
-    <button on:click={toggleAddMode} class:addMode={$milestones.addMode}>
+<div class="flex my-[3rem] justify-between items-center w-full min-w-[1020px]">
+    <LabelMilestoneNavTab />
+    <button on:click={toggleAddMode} class="btn issue create max-h-[44px] h-lvh" class:addMode={$milestones.addMode}>
+        <span>
+            <i class="bi bi-plus-lg"></i>
+        </span>
         마일스톤 추가
     </button>
+</div>
 
+<div class="mb-[3rem]">
     {#if $milestones.addMode}
         <MilestoneAddForm />
     {/if}
-
-    <MilestoneList />
 </div>
 
-<style>
-    .milestone-page {
-        padding: 20px;
-    }
-
-    button {
-        margin: 10px 0;
-        padding: 10px 20px;
-        background-color: #007bff;
-        color: white;
-        border: none;
-        border-radius: 5px;
-        cursor: pointer;
-        transition: opacity 0.3s;
-    }
-
-    button:hover {
-        background-color: #0056b3;
-    }
-
-    button.addMode {
-        opacity: 0.5;
-    }
-</style>
+<MilestoneList />

--- a/frontend/src/stores/milestone.js
+++ b/frontend/src/stores/milestone.js
@@ -1,7 +1,6 @@
 import {writable} from "svelte/store";
-import {postApi, getApi, patchApi, delApi, putApi} from "../service/api.js";
-
-const urlPrefix = '/api/v1';
+import {delApi, getApi, patchApi, postApi, putApi} from "../service/api.js";
+import {urlPrefix} from "../utils/constants.js";
 
 function setMilestones() {
     let initValues = {
@@ -76,6 +75,30 @@ function setMilestones() {
         })
     }
 
+    const patchMilestone = async (milestoneId, isOpen) => {
+        try {
+            const options = {
+                path: urlPrefix + `/milestones/status?milestoneId=${milestoneId}&isOpen=${isOpen}`,
+            }
+
+            await patchApi(options);
+
+            update(data => {
+                data.milestones = data.milestones.map(milestone => {
+                    if(milestone.id === milestoneId) {
+                        milestone.open = isOpen
+                    }
+                    return milestone;
+                });
+                return data;
+            })
+
+            alert('마일스톤을 닫았습니다.')
+        } catch (err) {
+            alert('마일스톤을 닫는 중 오류가 발생했습니다. 다시 시도해 주세요.')
+        }
+    }
+
     const updateMilestone = async (milestoneId, changes) => {
         try {
             const options = {
@@ -128,8 +151,32 @@ function setMilestones() {
         openEditModeMilestone,
         closeEditModeMilestone,
         updateMilestone,
-        deleteMilestone
+        deleteMilestone,
+        patchMilestone,
     }
 }
+
+// function getStatistic() {
+//     const getMilestoneCount = async () => {
+//
+//         try {
+//             const options = {
+//                 path: urlPrefix + '/milestones/count',
+//             }
+//
+//             const response = await getApi(options)
+//
+//             console.log('fetchCount:', response.countResult)
+//
+//             return response.countResult
+//         } catch (err) {
+//             throw err
+//         }
+//     }
+//
+//     return {
+//         getMilestoneCount,
+//     }
+// }
 
 export const milestones = setMilestones()

--- a/src/main/java/com/issuetracker/domain/milestone/MilestoneController.java
+++ b/src/main/java/com/issuetracker/domain/milestone/MilestoneController.java
@@ -21,10 +21,16 @@ public class MilestoneController {
     private final MilestoneService milestoneService;
 
     @GetMapping
-    public ResponseEntity<MilestoneListResponse> getMilestones(
+    public ResponseEntity<MilestoneListResponse> getMilestones() {
+        return ResponseEntity
+                .ok(milestoneService.getMilestones());
+    }
+
+    @GetMapping(params = "isOpen")
+    public ResponseEntity<MilestoneListResponse> getMilestonesByOpenCondition(
             @RequestParam(value = "isOpen", defaultValue = "true") boolean openStatus) {
         return ResponseEntity
-                .ok(milestoneService.getMilestones(openStatus));
+                .ok(milestoneService.getMilestonesByOpenCondition(openStatus));
     }
 
     @PostMapping
@@ -51,10 +57,17 @@ public class MilestoneController {
     }
 
     @GetMapping("/count")
-    public ResponseEntity<?> getMilestoneCount(@RequestParam(value = "isOpen", defaultValue = "true") boolean openStatus) {
+    public ResponseEntity<?> getMilestoneCount() {
         return ResponseEntity
                 .ok()
-                .body(Collections.singletonMap("countResult", milestoneService.count(openStatus)));
+                .body(Collections.singletonMap("countResult", milestoneService.count()));
+    }
+
+    @GetMapping(value = "/count", params = "isOpen")
+    public ResponseEntity<?> getMilestoneCountByOpenCondition(@RequestParam(value = "isOpen", defaultValue = "true") boolean openStatus) {
+        return ResponseEntity
+                .ok()
+                .body(Collections.singletonMap("countResult", milestoneService.countByOpenCondition(openStatus)));
     }
 
     @PatchMapping("/status")

--- a/src/main/java/com/issuetracker/domain/milestone/MilestoneService.java
+++ b/src/main/java/com/issuetracker/domain/milestone/MilestoneService.java
@@ -34,8 +34,14 @@ public class MilestoneService {
     }
 
     @Transactional(readOnly = true)
-    public MilestoneListResponse getMilestones(boolean openStatus) {
+    public MilestoneListResponse getMilestonesByOpenCondition(boolean openStatus) {
         List<MilestoneDetails> milestones = milestoneViewMapper.findAllByOpenStatus(openStatus);
+        return MilestoneListResponse.of(milestones);
+    }
+
+    @Transactional(readOnly = true)
+    public MilestoneListResponse getMilestones() {
+        List<MilestoneDetails> milestones = milestoneViewMapper.findAll();
         return MilestoneListResponse.of(milestones);
     }
 
@@ -51,7 +57,12 @@ public class MilestoneService {
     }
 
     @Transactional(readOnly = true)
-    public Long count(boolean openStatus) {
+    public Long count() {
+        return milestoneRepository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public Long countByOpenCondition(boolean openStatus) {
         return milestoneRepository.countByIsOpen(openStatus);
     }
 

--- a/src/main/java/com/issuetracker/domain/milestone/MilestoneViewMapper.java
+++ b/src/main/java/com/issuetracker/domain/milestone/MilestoneViewMapper.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface MilestoneViewMapper {
 
     List<MilestoneDetails> findAllByOpenStatus(boolean openStatus);
+    List<MilestoneDetails> findAll();
 }

--- a/src/main/resources/mapper/milestone/Milestone.xml
+++ b/src/main/resources/mapper/milestone/Milestone.xml
@@ -32,4 +32,18 @@
         ORDER BY
             M.CREATED_AT DESC
     </select>
+
+    <select id="findAll" resultMap="MilestoneDetailsResultMap">
+        SELECT M.MILESTONE_ID,
+               M.DESCRIPTION,
+               M.DUE_DATE,
+               M.IS_OPEN,
+               COUNT(I.ISSUE_ID)        AS TOTAL_ISSUES,
+               SUM(IF(I.IS_OPEN, 1, 0)) AS OPEN_ISSUES
+        FROM MILESTONE M
+                 LEFT JOIN
+             ISSUE I ON M.MILESTONE_ID = I.MILESTONE_ID
+        GROUP BY M.MILESTONE_ID, M.DESCRIPTION, M.DUE_DATE, M.IS_OPEN, M.CREATED_AT
+        ORDER BY M.CREATED_AT DESC
+    </select>
 </mapper>

--- a/src/test/java/com/issuetracker/domain/milestone/MilestoneControllerTest.java
+++ b/src/test/java/com/issuetracker/domain/milestone/MilestoneControllerTest.java
@@ -149,8 +149,8 @@ class MilestoneControllerTest {
         String responseJsonOfOpened = objectMapper.writeValueAsString(openMilestones);
         String responseJsonOfClosed = objectMapper.writeValueAsString(closedMilestones);
 
-        given(milestoneService.getMilestones(true)).willReturn(openMilestones);
-        given(milestoneService.getMilestones(false)).willReturn(closedMilestones);
+        given(milestoneService.getMilestonesByOpenCondition(true)).willReturn(openMilestones);
+        given(milestoneService.getMilestonesByOpenCondition(false)).willReturn(closedMilestones);
 
         // when & then
         performRequestAndVerify(urlForOpened, responseJsonOfOpened);
@@ -209,12 +209,12 @@ class MilestoneControllerTest {
 
     @Test
     @DisplayName("열린 마일스톤 수를 조회할 수 있다")
-    void getMilestoneCount() throws Exception {
+    void getMilestoneCountByOpenCondition() throws Exception {
         // given
         boolean openStatus = true;
         Long countResult = 5L;
         String url = urlPrefix + "/milestones/count?isOpen=" + openStatus;
-        given(milestoneService.count(openStatus)).willReturn(countResult);
+        given(milestoneService.countByOpenCondition(openStatus)).willReturn(countResult);
 
         // when
         ResultActions result = mockMvc.perform(


### PR DESCRIPTION
# 🚀 Pull Request
마일스톤 화면 작업을 진행했습니다.
마일스톤을 열고 닫는 기능, 열린 마일스톤과 닫힌 마일스톤을 탭 전환을 통해 보는 기능 등을 구현했습니다.
마일스톤 기능 구현 중 필요한 API는 컨트롤러를 추가했습니다.

추가로 레이블 화면에서 css 일부가 수정되었습니다.

## 구현 내용
### 프론트엔드
- 마일스톤 등록, 수정 화면에 테일윈드 Css 적용
- 마일스톤 열기, 닫기 기능 추가
- 마일스톤 진행률 표시 추가
- 열린 마일스톤, 닫힌 마일스톤 화면 전환 기능 추가
- 마일스톤이 없는 화면 추가
- 레이블, 마일스톤 스토어를 구독해서 개수를 가져오는 기능 추가

### 백엔드
- 마일스톤 전체 조회 기능 추가
- 마일스톤 전체 개수 조회 기능 추가

## 관련 이슈
close #71 
