### PR TITLE
[Fix/#89] 댓글 편집 시 기존 이슈 편집 내용 원상복구되던 문제 해결

### DIFF
--- a/frontend/src/pages/issue/IssueDetailPage.svelte
+++ b/frontend/src/pages/issue/IssueDetailPage.svelte
@@ -60,6 +60,7 @@
 
     /* 업데이트 된 이슈 제목을 IssueEditTitleForm 컴포넌트로부터 받아 갱신 */
     function updateIssueTitle(newTitle) {
+        issueData.title = newTitle
         defaultTitle = newTitle;
     }
 
@@ -79,6 +80,7 @@
 
     /* 업데이트 된 이슈 본문 내용을 IssueEditContentForm 컴포넌트로부터 받아 갱신 */
     function updateIssueContent(newContent) {
+        issueData.content = newContent
         defaultContent = newContent;
     }
 
@@ -131,6 +133,7 @@
     $: issueState = issueData.open;
 
     const onUpdateIssueState = (issueId) => {
+        issueData.open = !issueData.open
         issueState = !issueState
         issues.updateIssueState(issueId.toString(), issueState);
     }

--- a/frontend/src/stores/issue.js
+++ b/frontend/src/stores/issue.js
@@ -154,35 +154,43 @@ function setIssues() {
     }
 
     const updateIssue = async (issueId, form) => {
-
         try {
-
             const updateData = {
                 title: form.title !== null ? form.title : null,
                 content: form.content !== null ? form.content : null
-            }
+            };
 
             const options = {
                 path: `${urlPrefix}/issues/${issueId}`,
                 data: updateData,
                 access_token: get(auth).accessToken,
-            }
+            };
 
-            await patchApi(options)
+            await patchApi(options);
 
-            if (form.title) {
-                closeEditModeIssueTitle()
-            }
+            // 상태 업데이트
+            update(data => {
+                data.issueList = data.issueList.map(issue => {
+                    if (issue.id === issueId) {
+                        return {
+                            ...issue,
+                            title: form.title !== null ? form.title : issue.title,
+                            content: form.content !== null ? form.content : issue.content,
+                        };
+                    }
+                    return issue;
+                });
 
-            if (form.content) {
-                closeEditModeIssueContent()
-            }
+                // 편집 모드 종료
+                data.editModeTitle = form.title ? '' : data.editModeTitle;
+                data.editModeContent = form.content ? '' : data.editModeContent;
+                return data;
+            });
 
-            return true
-        }
-        catch(error) {
-            alert('수정 중 오류가 발생했습니다. 다시 시도해 주세요.')
-            throw error
+            return true;
+        } catch (error) {
+            alert('수정 중 오류가 발생했습니다. 다시 시도해 주세요.');
+            throw error;
         }
     }
 


### PR DESCRIPTION
# 🚀 Pull Request

## 구현 내용
- 댓글 편집 시 기존 이슈 편집 내용 원상복구되던 문제 해결
- 댓글 편집이 이슈 편집에 영향을 끼치던 문제가 있었지만, 각각 독립적으로 반영되도록 수정했습니다

## 관련 이슈
close #89 
